### PR TITLE
make grpc before rebar compile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
         with:
           toolchain: stable
       - name: build
-        run: ./rebar3 compile
+        run: |
+          make grpc
+          ./rebar3 compile
       - name: build test
         run: ./rebar3 as test compile
       - name: tar

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
-.PHONY: compile clean test rel run docker-build docker-test docker-run
+.PHONY: compile clean test rel run grpc docker-build docker-test docker-run
+
+grpc_services_directory=src/grpc/autogen
 
 REBAR=./rebar3
 
-compile: |
-	$(REBAR) compile 
+compile: | $(grpc_services_directory)
+	BUILD_WITHOUT_QUIC=1 $(REBAR) compile
 	$(REBAR) format
 
 clean:
 	git clean -dXfffffffffff
 
-test: |
+test: | $(grpc_services_directory)
 	$(REBAR) fmt --verbose --check rebar.config
 	$(REBAR) fmt --verbose --check "{src,include,test}/**/*.{hrl,erl,app.src}" --exclude-files "src/grpc/autogen/**/*"
 	$(REBAR) fmt --verbose --check "config/{test,sys}.{config,config.src}"
@@ -18,9 +20,10 @@ test: |
 	$(REBAR) ct --readable=true
 	$(REBAR) dialyzer
 
-rel: $(REBAR) release
+rel: | $(grpc_services_directory)
+	$(REBAR) release
 
-run: |
+run: | $(grpc_services_directory)
 	_build/default/rel/hpr/bin/hpr foreground
 
 docker-build:
@@ -29,8 +32,17 @@ docker-build:
 docker-test:
 	docker run --rm -it --init --name=helium_router_test quay.io/team-helium/hpr:local make test
 
-docker-run: 
+docker-run:
 	docker run --rm -it --init --network=host --name=helium_packet_router quay.io/team-helium/hpr:local
+
+grpc:
+	REBAR_CONFIG="config/grpc_server_gen.config" $(REBAR) grpc gen
+	REBAR_CONFIG="config/grpc_client_gen.config" $(REBAR) grpc gen
+
+$(grpc_services_directory):
+	@echo "grpc service directory $(directory) does not exist, generating services"
+	$(REBAR) get-deps
+	$(MAKE) grpc
 
 # Pass all unknown targets straight to rebar3 (e.g. `make dialyzer`)
 %:


### PR DESCRIPTION
Enable gRPC build before `rebar3 compile` in GitHub CI test builds, and add grpc/protobufs things to `Makefile`, even though the protobufs artifacts get added in a different PR.

This is needed so PR#9 can build since it adds grpc things.  Apparently, GitHub CI changes must be in `main` branch in order to be used.  

However, it seems that we have a chicken vs egg situation (bootstrapping paradox) where GitHub CI won't fully use the new thing yet doesn't build properly without it.  Since **files in this PR are an excerpt** of [PR#9](https://github.com/helium/helium-packet-router/pull/9), maybe just merge that one and iterate as needed.