### PR TITLE
cp multi dest

### DIFF
--- a/src/hpr_sup.erl
+++ b/src/hpr_sup.erl
@@ -44,9 +44,12 @@ init([]) ->
 
     ok = hpr_routing:init(),
 
+    RedirectMap = application:get_env(hpr, redirect_by_region, #{}),
+
     ChildSpecs = [
         ?WORKER(hpr_metrics, [#{}]),
         ?WORKER(hpr_routing_config_worker, [#{base_dir => BaseDir}]),
+        ?WORKER(hpr_gwmp_redirect_worker, [RedirectMap]),
         ?SUP(hpr_gwmp_udp_sup, [])
     ],
     {ok, {

--- a/src/protocols/gwmp/hpr_gwmp_redirect_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_redirect_worker.erl
@@ -1,0 +1,124 @@
+%%%-------------------------------------------------------------------
+%% @doc
+%% == GWMP Redirect Worker ==
+%%
+%% This worker enables remapping source destinations on the fly. Need
+%% to route a packet, but don't know the correct destination until you
+%% know the originating region? This worker fills that need.
+%%
+%% Starts a udp socket with `port'.
+%%
+%% The worker will acknowledge `pull_data' as a courtesy.
+%%
+%% Receiving a `push_data' the worker will pull the `regi' key from
+%% the `stats' map in the payload and return a special message of
+%% where that packet should be sent instead.
+%%
+%% Unmapped regions will be logged and dropped.
+%%
+%% Usage:
+%% /sys.config.src
+%% {hpr, [
+%%     {redirect_by_region, #{
+%%         port => 1777,
+%%         remap => #{
+%%             <<"US915">> => <<"127.0.0.1:1778">>,
+%%             <<"EU868">> => <<"127.0.0.1:1779">>,
+%%             <<"AS923_1">> => <<"127.0.0.1:1780">>
+%%         }
+%%     }}
+%% ]}
+%%
+%% @end
+%%%-------------------------------------------------------------------
+-module(hpr_gwmp_redirect_worker).
+
+-behaviour(gen_server).
+
+-include("semtech_udp.hrl").
+
+%% API
+-export([
+    start_link/1
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-record(state, {
+    port :: non_neg_integer(),
+    remap :: map(),
+    socket :: gen_udp:socket()
+}).
+
+start_link(Args) ->
+    case maps:size(Args) of
+        0 -> ignore;
+        _ -> gen_server:start_link({local, ?MODULE}, ?MODULE, Args, [])
+    end.
+
+init(Args) ->
+    #{port := Port, remap := Map} = Args,
+
+    {ok, Socket} = gen_udp:open(Port, [binary, {active, true}]),
+
+    {ok, #state{
+        port = Port,
+        remap = Map,
+        socket = Socket
+    }}.
+
+handle_call(Request, From, State) ->
+    lager:warning("rcvd unknown call msg: ~p from: ~p", [Request, From]),
+    {reply, ok, State}.
+
+handle_cast(Request, State) ->
+    lager:warning("rcvd unknown cast msg: ~p", [Request]),
+    {noreply, State}.
+
+handle_info(
+    {udp, Socket, Address, Port, IncomingData},
+    #state{socket = Socket, remap = ReMap} = State
+) ->
+    try semtech_udp:identifier(IncomingData) of
+        ?PUSH_DATA ->
+            TxPk = semtech_udp:json_data(IncomingData),
+            Stat = maps:get(<<"stat">>, TxPk),
+            Region = maps:get(<<"regi">>, Stat),
+            case maps:get(Region, ReMap, undefined) of
+                undefined ->
+                    lager:warning([{region, Region}], "dropping redirect for unmapped region"),
+                    dropped;
+                NewDest ->
+                    lager:debug([{region, Region}], "redirecting gateway"),
+                    NewData = jsx:encode(#{
+                        new_dest => NewDest,
+                        packet => erlang:binary_to_list(IncomingData)
+                    }),
+                    OutgoingData = <<"REMAP: ", NewData/binary>>,
+                    gen_udp:send(Socket, Address, Port, OutgoingData),
+                    redirect
+            end;
+        ?PULL_DATA ->
+            Token = semtech_udp:token(IncomingData),
+            OutgoingData = semtech_udp:pull_ack(Token),
+            gen_udp:send(Socket, Address, Port, OutgoingData);
+        _ ->
+            noop
+    catch
+        _E:_R ->
+            lager:error([{type, _E}, {reason, _R}], "could not identify semtech_udp packet")
+    end,
+    {noreply, State};
+handle_info(_Msg, State) ->
+    lager:info("rcvd unknown info msg: ~p, ~p", [_Msg, State]),
+    {noreply, State}.
+
+terminate(_Reason, _State = #state{socket = Socket}) ->
+    ok = gen_udp:close(Socket).

--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -46,7 +46,8 @@
     response_stream :: undefined | tuple(),
     pull_data = #{} :: pull_data_map(),
     pull_data_timer :: non_neg_integer(),
-    shutdown_timer :: {Timeout :: non_neg_integer(), Timer :: reference()}
+    shutdown_timer :: {Timeout :: non_neg_integer(), Timer :: reference()},
+    dest_remap = #{} :: #{socket_dest() => socket_dest()}
 }).
 
 %%%===================================================================
@@ -63,7 +64,7 @@ start_link(Args) ->
     SocketDest :: socket_dest()
 ) -> ok | {error, any()}.
 push_data(WorkerPid, Data, StreamHandler, SocketDest) ->
-    gen_server:call(WorkerPid, {push_data, Data, StreamHandler, SocketDest}).
+    gen_server:cast(WorkerPid, {push_data, Data, StreamHandler, SocketDest}).
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -98,34 +99,35 @@ init(Args) ->
         shutdown_timer = {ShutdownTimeout, ShutdownRef}
     }}.
 
-handle_call(
-    {push_data, _Data = {Token, Payload}, StreamHandler, SocketDest},
-    _From,
+handle_call(Request, From, State) ->
+    lager:warning("rcvd unknown call msg: ~p from: ~p", [Request, From]),
+    {reply, ok, State}.
+
+handle_cast(
+    {push_data, _Data = {Token, Payload}, StreamHandler, SocketDest0},
     #state{
         push_data = PushData,
         shutdown_timer = {ShutdownTimeout, ShutdownRef},
-        socket = Socket
+        socket = Socket,
+        dest_remap = DestMap
     } =
         State0
 ) ->
     _ = erlang:cancel_timer(ShutdownRef),
 
+    SocketDest = maps:get(SocketDest0, DestMap, SocketDest0),
     State = maybe_send_pull_data(SocketDest, State0),
+    {_Reply, TimerRef} = send_push_data(Token, Payload, Socket, SocketDest),
 
-    {Reply, TimerRef} = send_push_data(Token, Payload, Socket, SocketDest),
     {NewPushData, NewShutdownTimer} = new_push_and_shutdown(
         Token, Payload, TimerRef, PushData, ShutdownTimeout
     ),
 
-    {reply, Reply, State#state{
+    {noreply, State#state{
         push_data = NewPushData,
         response_stream = StreamHandler,
         shutdown_timer = NewShutdownTimer
     }};
-handle_call(Request, From, State) ->
-    lager:warning("rcvd unknown call msg: ~p from: ~p", [Request, From]),
-    {reply, ok, State}.
-
 handle_cast(Request, State) ->
     lager:warning("rcvd unknown cast msg: ~p", [Request]),
     {noreply, State}.
@@ -138,7 +140,7 @@ handle_info(
         {noreply, _} = NoReply -> NoReply
     catch
         _E:_R ->
-            lager:error("failed to handle UDP packet ~p: ~p/~p", [Data, _E, _R]),
+            lager:error("failed to handle UDP packet ~p/~p", [_E, _R]),
             {noreply, State}
     end;
 handle_info(
@@ -214,26 +216,49 @@ handle_udp(
         pull_data = PullDataMap0,
         socket = Socket,
         response_stream = StreamHandler,
-        pubkeybin = PubKeyBin
+        pubkeybin = PubKeyBin,
+        dest_remap = DestMap0
     } = State0
 ) ->
     State1 =
-        case semtech_udp:identifier(Data) of
-            ?PUSH_ACK ->
-                PushData1 = handle_push_ack(Data, PushData0),
-                State0#state{push_data = PushData1};
-            ?PULL_ACK ->
-                PullDataMap1 = handle_pull_ack(Data, DataSrc, PullDataMap0, PullDataTimer),
-                State0#state{pull_data = PullDataMap1};
-            ?PULL_RESP ->
-                %% FIXME: include data source for socket ack
-                ok = handle_pull_resp(Data, DataSrc, PubKeyBin, Socket, StreamHandler),
-                State0;
-            _Id ->
-                lager:warning("got unknown identifier ~p for ~p", [_Id, Data]),
-                State0
+        case Data of
+            <<"REMAP: ", _/binary>> ->
+                case maybe_remap_dest(DestMap0, DataSrc, Data) of
+                    noupdate ->
+                        State0;
+                    {DestMap1, Resend} ->
+                        {{A, B, C, D}, Port} = DataSrc,
+                        Key = {lists:flatten(io_lib:format("~p.~p.~p.~p", [A, B, C, D])), Port},
+                        ?MODULE:push_data(self(), Resend, StreamHandler,  maps:get(Key, DestMap1)),
+                        State0#state{dest_remap = DestMap1}
+                end;
+            _ ->
+                case semtech_udp:identifier(Data) of
+                    ?PUSH_ACK ->
+                        PushData1 = handle_push_ack(Data, PushData0),
+                        State0#state{push_data = PushData1};
+                    ?PULL_ACK ->
+                        PullDataMap1 = handle_pull_ack(Data, DataSrc, PullDataMap0, PullDataTimer),
+                        State0#state{pull_data = PullDataMap1};
+                    ?PULL_RESP ->
+                        ok = handle_pull_resp(Data, DataSrc, PubKeyBin, Socket, StreamHandler),
+                        State0;
+                    _Id ->
+                        lager:warning("got unknown identifier ~p for ~p", [_Id, Data]),
+                        State0
+                end
         end,
     {noreply, State1}.
+
+maybe_remap_dest(Map, {{A, B, C, D}, Port}, <<"REMAP: ", Data/binary>>) ->
+    #{<<"new_dest">> := New, <<"packet">> := Packet0} = jsx:decode(Data, [return_maps]),
+    %% NOTE: binaries don't encode 1:1
+    Packet = erlang:list_to_binary(Packet0),
+    Key = {lists:flatten(io_lib:format("~p.~p.~p.~p", [A, B, C, D])), Port},
+    Token = semtech_udp:token(Packet),
+    {Map#{Key => hpr_gwmp_router:route_to_dest(New)}, {Token, Packet}};
+maybe_remap_dest(_, _, _) ->
+    noop.
 
 -spec pubkeybin_to_mac(binary()) -> binary().
 pubkeybin_to_mac(PubKeyBin) ->

--- a/src/protocols/hpr_gwmp_router.erl
+++ b/src/protocols/hpr_gwmp_router.erl
@@ -101,10 +101,9 @@ packet_up_to_push_data(Up, GatewayTime) ->
     ),
     {Token, Data}.
 
--spec route_to_dest(hpr_route:route()) -> {Address :: string(), Port :: non_neg_integer()}.
-route_to_dest(Route) ->
-    Lns = hpr_route:lns(Route),
-    case binary:split(Lns, <<":">>) of
+-spec route_to_dest(binary() | hpr_route:route()) -> {Address :: string(), Port :: non_neg_integer()}.
+route_to_dest(Route) when erlang:is_binary(Route) ->
+    case binary:split(Route, <<":">>) of
         [Address, Port] ->
             {
                 erlang:binary_to_list(Address),
@@ -112,4 +111,7 @@ route_to_dest(Route) ->
             };
         Err ->
             throw({route_to_dest_err, Err})
-    end.
+    end;
+route_to_dest(Route) ->
+    Lns = hpr_route:lns(Route),
+    route_to_dest(Lns).


### PR DESCRIPTION
The ChirpStack Application Server V4 supports multiple regions.
It does this by encoding the region into the mqtt topic the gateway-bridge publishes to.

This is a first draft solution to get _all_ regions routing to a single LNS without needing to change the Config Service/Protobuf combo.

This PR defines a completely out of udp specification `"REMAP:"` message that our udp workers know about to map one destination into another.

**Setup:**
A localhost udp_port is started that will act as a ChirpStack LNS proxy. 
It knows how to pull the Region from a `RxPk` Stat map (another out of semtech_udp spec thing we do), and look at it's setting and return a correct routing address for a gateway to send its data instead.

In normal operation, a udp_worker should only send 2 messages to this proxy before directing its data elsewhere.

The Config service should be setup to point to `locahost` and the `port` provided in the `sys.config.src` file.

**Sample Config:**
```erlang
%% /sys.config.src
{hpr, [
    {redirect_by_region, #{
        port => 1777,
        remap => #{
            <<"US915">> => <<"127.0.0.1:1778">>,
            <<"EU868">> => <<"127.0.0.1:1779">>,
            <<"AS923_1">> => <<"127.0.0.1:1780">>
        }
    }}
]}
```