### PR TITLE
make sure metadata for logging is all strings

### DIFF
--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -83,7 +83,7 @@ init(Args) ->
     PullDataTimer = maps:get(pull_data_timer, Args, ?PULL_DATA_TIMER),
 
     lager:md([
-        {gateway_mac, binary:encode_hex(pubkeybin_to_mac(PubKeyBin))},
+        {gateway_mac, erlang:binary_to_list(binary:encode_hex(pubkeybin_to_mac(PubKeyBin)))},
         {pubkey, libp2p_crypto:bin_to_b58(PubKeyBin)}
     ]),
 


### PR DESCRIPTION
Promtail doesn't like some types of fields. And it happens to be binaries.