### PR TITLE
odds n ends

### DIFF
--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -3,7 +3,7 @@
         {config_worker, #{
             host => "${HPR_CONFIG_WORKER_HOST}",
             port => "${HPR_CONFIG_WORKER_PORT:-8080}",
-            file_backup_path => "/var/data/hpr/config_worker.backup"
+            file_backup_path => "/var/data/config_worker.backup"
         }}
     ]},
     {grpcbox, [

--- a/src/hpr_config.erl
+++ b/src/hpr_config.erl
@@ -18,6 +18,16 @@ init() ->
     ok.
 
 -spec update_routes(client_config_pb:routes_res_v1_pb()) -> ok.
+update_routes(#{routes := []}) ->
+    case application:get_env(hpr, hpr_config_empty_routes_delete_all, false) of
+        true ->
+            lager:info("applying empty routes update"),
+            true = ets:delete_all_objects(?DEVADDRS_ETS),
+            true = ets:delete_all_objects(?EUIS_ETS);
+        false ->
+            lager:info("ignoring empty routes update"),
+            ok
+    end;
 update_routes(#{routes := Routes}) ->
     true = ets:delete_all_objects(?DEVADDRS_ETS),
     true = ets:delete_all_objects(?EUIS_ETS),

--- a/src/hpr_config.erl
+++ b/src/hpr_config.erl
@@ -154,8 +154,13 @@ test_eui_lookup() ->
         ],
         euis => [#{app_eui => 1, dev_eui => 2}, #{app_eui => 3, dev_eui => 4}],
         oui => 1,
-        protocol => {http_roaming, #{ip => <<"lns1.testdomain.com">>, port => 80}}
+        server => #{
+            host => <<"lns1.testdomain.com">>,
+            port => 80,
+            protocol => {http_roaming, #{}}
+        }
     }),
+
     Route2 = hpr_route:new(#{
         net_id => 0,
         devaddr_ranges => [
@@ -164,7 +169,11 @@ test_eui_lookup() ->
         ],
         euis => [#{app_eui => 1, dev_eui => 0}, #{app_eui => 5, dev_eui => 6}],
         oui => 1,
-        protocol => {http_roaming, #{ip => <<"lns2.testdomain.com">>, port => 80}}
+        server => #{
+            host => <<"lns2.testdomain.com">>,
+            port => 80,
+            protocol => {http_roaming, #{}}
+        }
     }),
 
     ok = insert_route(Route1),
@@ -186,7 +195,11 @@ route_v1() ->
         ],
         euis => [#{app_eui => 1, dev_eui => 2}, #{app_eui => 3, dev_eui => 4}],
         oui => 1,
-        protocol => {http_roaming, #{ip => <<"lns1.testdomain.com">>, port => 80}}
+        server => #{
+            host => <<"lns1.testdomain.com">>,
+            port => 80,
+            protocol => {http_roaming, #{}}
+        }
     }).
 
 -endif.


### PR DESCRIPTION
- remove `hpr` from file backup path. In docker-compose we're already mounting to a nested `hpr` dir, and this creates a nested dir.
- add a flag for config to not blow away all routes if the config service sends an empty list of routes.
  - Hopefully removed in the future, but useful right now for testing with a routing file but an empty config service.
- fixup leftover eunit route creations. Not technically failures, but good to have everything consistent.