### PR TITLE
unknown pull ack

### DIFF
--- a/src/hpr_utils.erl
+++ b/src/hpr_utils.erl
@@ -2,9 +2,11 @@
 
 -export([
     gateway_name/1,
+    gateway_mac/1,
     int_to_hex/1,
     bin_to_hex/1,
-    hex_to_bin/1
+    hex_to_bin/1,
+    pubkeybin_to_mac/1
 ]).
 
 -spec gateway_name(PubkeyBin :: libp2p_crypto:pubkey_bin() | string()) -> string().
@@ -14,6 +16,10 @@ gateway_name(PubkeyBin) when is_binary(PubkeyBin) ->
 gateway_name(B58) when is_list(B58) ->
     {ok, Name} = erl_angry_purple_tiger:animal_name(B58),
     Name.
+
+-spec gateway_mac(PubKeyBin :: libp2p_crypto:pubkey_bin()) -> string().
+gateway_mac(PubKeyBin) ->
+    erlang:binary_to_list(binary:encode_hex(pubkeybin_to_mac(PubKeyBin))).
 
 -spec int_to_hex(Integer :: integer()) -> string().
 int_to_hex(Integer) ->
@@ -32,3 +38,7 @@ hex_to_bin(Hex) ->
         end
      || <<X:8/integer, Y:8/integer>> <= Hex
     >>.
+
+-spec pubkeybin_to_mac(binary()) -> binary().
+pubkeybin_to_mac(PubKeyBin) ->
+    <<(xxhash:hash64(PubKeyBin)):64/unsigned-integer>>.

--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -480,7 +480,6 @@ udp_send(Socket, {Address, Port}, Data) ->
 -spec maybe_resolve_addr({string(), inet:port_number()}, IpResolutions :: map()) ->
     {{string() | inet:ip_address(), inet:port_number()}, map()}.
 maybe_resolve_addr({Addr, Port} = Dest, AddrResolutions) ->
-    %% ct:print("resolving :: ~p :: maybe :: ~p", [Dest, AddrResolutions]),
     case maps:get(Dest, AddrResolutions, undefined) of
         undefined ->
             New =
@@ -496,7 +495,7 @@ maybe_resolve_addr({Addr, Port} = Dest, AddrResolutions) ->
     end.
 
 resolve_addr(Addr) ->
-    case inet:gethostbyaddr(Addr) of
+    case inet:gethostbyname(Addr) of
         {ok, #hostent{h_addr_list = [IPAddr]}} ->
             IPAddr;
         {ok, #hostent{h_addr_list = [IPAddr | _]}} ->

--- a/src/protocols/hpr_protocol_gwmp.erl
+++ b/src/protocols/hpr_protocol_gwmp.erl
@@ -59,7 +59,7 @@ txpk_to_packet_down(TxPkBin) ->
 packet_up_to_push_data(Up, GatewayTime) ->
     Token = semtech_udp:token(),
     PubKeyBin = hpr_packet_up:gateway(Up),
-    MAC = hpr_gwmp_worker:pubkeybin_to_mac(PubKeyBin),
+    MAC = hpr_utils:pubkeybin_to_mac(PubKeyBin),
 
     %% TODO: Add back potential geo stuff
     %% CP breaks if {lati, long} are not parseable number

--- a/test/hpr_protocol_gwmp_SUITE.erl
+++ b/test/hpr_protocol_gwmp_SUITE.erl
@@ -15,6 +15,7 @@
     shutdown_idle_worker_test/1,
     pull_data_test/1,
     pull_ack_test/1,
+    pull_ack_hostname_test/1,
     gateway_dest_redirect_test/1
 ]).
 
@@ -43,6 +44,7 @@ all() ->
         shutdown_idle_worker_test,
         pull_data_test,
         pull_ack_test,
+        pull_ack_hostname_test,
         gateway_dest_redirect_test
     ].
 
@@ -348,6 +350,63 @@ pull_ack_test(_Config) ->
 
     ok.
 
+pull_ack_hostname_test(_Config) ->
+    %% Mostly a copy of `pull_ack_test', but with some assertions around the
+    %% inet module to make sure we're attempting to resolve hostnames.
+    PacketUp = fake_join_up_packet(),
+    PubKeyBin = hpr_packet_up:gateway(PacketUp),
+
+    TestURL = "test_url.for.resolving",
+
+    meck:new(inet, [unstick, passthrough]),
+    %% Resovle to localhost so we can communicate
+    meck:expect(
+        inet,
+        gethostbyname,
+        1,
+        {ok, {hostent, TestURL, [], inet, 4, [{127, 0, 0, 1}]}}
+    ),
+
+    Route = test_route(erlang:list_to_binary(TestURL), 1777),
+
+    {ok, RcvSocket} = gen_udp:open(1777, [binary, {active, true}]),
+    hpr_protocol_gwmp:send(PacketUp, unused_test_stream_handler, Route),
+
+    %% Initial PULL_DATA, grab the address and port for responding
+    {ok, Token, Address, Port} =
+        receive
+            {udp, RcvSocket, A, P, Data} ->
+                ?assertEqual(pull_data, semtech_id_atom(Data)),
+                T = semtech_udp:token(Data),
+                {ok, T, A, P}
+        after timer:seconds(2) -> ct:fail({no_pull_data})
+        end,
+    ?assert(erlang:is_binary(Token)),
+
+    %% There is an outstanding pull_data
+    {ok, WorkerPid} = hpr_gwmp_sup:lookup_worker(PubKeyBin),
+    ?assertEqual(
+        1,
+        maps:size(element(6, sys:get_state(WorkerPid))),
+        "1 outstanding pull_data"
+    ),
+
+    %% send pull ack from server
+    PullAck = semtech_udp:pull_ack(Token),
+    ok = gen_udp:send(RcvSocket, Address, Port, PullAck),
+
+    %% pull_data has been acked
+    ok = test_utils:wait_until(fun() ->
+        0 == maps:size(element(6, sys:get_state(WorkerPid)))
+    end),
+
+    %% ensure url was resolved
+    ?assertEqual(TestURL, meck:capture(first, inet, gethostbyname, '_', 1)),
+
+    meck:unload(),
+
+    ok.
+
 gateway_dest_redirect_test(_Config) ->
     Route = test_route(?REDIRECT_WORKER_PORT),
 
@@ -408,13 +467,16 @@ gateway_dest_redirect_test(_Config) ->
 %% ===================================================================
 
 test_route(Port) ->
+    test_route(<<"127.0.0.1">>, Port).
+
+test_route(Host, Port) ->
     hpr_route:new(#{
         net_id => 1337,
         devaddr_ranges => [],
         euis => [],
         oui => 42,
         server => #{
-            host => <<"127.0.0.1">>,
+            host => Host,
             port => Port,
             protocol => {gwmp, #{mapping => []}}
         }

--- a/test/hpr_protocol_gwmp_SUITE.erl
+++ b/test/hpr_protocol_gwmp_SUITE.erl
@@ -304,7 +304,7 @@ pull_data_test(_Config) ->
     %% Initial PULL_DATA
     {ok, Token, MAC} = expect_pull_data(RcvSocket, route_pull_data),
     ?assert(erlang:is_binary(Token)),
-    ?assertEqual(MAC, hpr_gwmp_worker:pubkeybin_to_mac(PubKeyBin)),
+    ?assertEqual(MAC, hpr_utils:pubkeybin_to_mac(PubKeyBin)),
 
     ok.
 


### PR DESCRIPTION
- Add gateway name to metadata for gwmp worker.
- Correct resolving hostnames.

I had previously used `gethostbyaddr` which expected to resolve an IP address, and was only feeding it names. 
This would hit the default branch and continue using the "unresolvable" name. Pull_Data would be sent, and the worker wouldn't know about the Address responding with the Pull_Ack, and would mark it `unknown`.