### PR TITLE
unknown pull ack 2

### DIFF
--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -175,14 +175,7 @@ handle_info(
             lager:debug([{dest, SocketDest}], "not resending pull_data to remapped destination"),
             {noreply, State};
         false ->
-            case
-                send_pull_data(#{
-                    pubkeybin => PubKeyBin,
-                    socket => Socket,
-                    dest => SocketDest,
-                    pull_data_timer => PullDataTimer
-                })
-            of
+            case send_pull_data(PubKeyBin, Socket, SocketDest, PullDataTimer) of
                 {ok, RefAndToken} ->
                     PullDataMap1 = maps:put(SocketDest, RefAndToken, PullDataMap0),
                     {noreply, State#state{pull_data = PullDataMap1}};
@@ -290,20 +283,13 @@ new_push_and_shutdown(Token, Data, TimerRef, PushData, ShutdownTimeout) ->
     NewShutdownTimer = {ShutdownTimeout, schedule_shutdown(ShutdownTimeout)},
     {NewPushData, NewShutdownTimer}.
 
--spec send_pull_data(#{
-    pubkeybin := libp2p_crypto:pubkey_bin(),
-    socket := gen_udp:socket(),
-    dest := socket_dest(),
-    pull_data_timer := non_neg_integer()
-}) -> {ok, #{timer_ref := reference(), token := binary()}} | {error, any()}.
-send_pull_data(
-    #{
-        pubkeybin := PubKeyBin,
-        socket := Socket,
-        dest := SocketDest,
-        pull_data_timer := PullDataTimer
-    }
-) ->
+-spec send_pull_data(
+    PubKeybin :: libp2p_crypto:pubkey_bin(),
+    Socket :: gen_udp:socket(),
+    Dest :: socket_dest(),
+    PullDataTimer :: non_neg_integer()
+) -> {ok, #{timer_ref := reference(), token := binary()}} | {error, any()}.
+send_pull_data(PubKeyBin, Socket, SocketDest, PullDataTimer) ->
     Token = semtech_udp:token(),
     Data = semtech_udp:pull_data(Token, hpr_utils:pubkeybin_to_mac(PubKeyBin)),
     case udp_send(Socket, SocketDest, Data) of
@@ -370,21 +356,16 @@ handle_pull_resp(Data, DataSrc, PubKeyBin, Socket, Stream) ->
 
     %% Ack the downlink
     Token = semtech_udp:token(Data),
-    send_tx_ack(Token, #{pubkeybin => PubKeyBin, socket => Socket, socket_dest => DataSrc}),
+    send_tx_ack(Token, PubKeyBin, Socket, DataSrc),
     ok.
 
 -spec send_tx_ack(
-    binary(),
-    #{
-        pubkeybin := libp2p_crypto:pubkey_bin(),
-        socket := gen_udp:socket(),
-        socket_dest := socket_dest()
-    }
+    Token :: binary(),
+    PubKeyBin :: libp2p_crypto:pubkey_bin(),
+    Socket :: gen_udp:socket(),
+    SocketDest :: socket_dest()
 ) -> ok | {error, any()}.
-send_tx_ack(
-    Token,
-    #{pubkeybin := PubKeyBin, socket := Socket, socket_dest := SocketDest}
-) ->
+send_tx_ack(Token, PubKeyBin, Socket, SocketDest) ->
     Data = semtech_udp:tx_ack(Token, hpr_utils:pubkeybin_to_mac(PubKeyBin)),
     Reply = udp_send(Socket, SocketDest, Data),
     lager:debug(
@@ -433,14 +414,7 @@ maybe_send_pull_data(
                 socket = Socket,
                 pull_data_timer = PullDataTimer
             } = State,
-            case
-                send_pull_data(#{
-                    pubkeybin => PubKeyBin,
-                    socket => Socket,
-                    dest => SocketDest,
-                    pull_data_timer => PullDataTimer
-                })
-            of
+            case send_pull_data(PubKeyBin, Socket, SocketDest, PullDataTimer) of
                 {ok, RefAndToken} ->
                     State#state{
                         pull_data = maps:put(

--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -36,7 +36,7 @@
 -define(SERVER, ?MODULE).
 
 -type pull_data_map() :: #{
-    socket_dest() => #{timer_ref := reference(), token := binary()}
+    socket_dest() => acknowledged | #{timer_ref := reference(), token := binary()}
 }.
 
 -type socket_address() :: inet:socket_address() | inet:hostname().
@@ -346,7 +346,7 @@ handle_pull_ack(Data, DataSrc, PullDataMap, PullDataTimer) ->
         {Token, #{token := Token, timer_ref := TimerRef}} ->
             _ = erlang:cancel_timer(TimerRef),
             _ = schedule_pull_data(PullDataTimer, DataSrc),
-            maps:remove(DataSrc, PullDataMap);
+            maps:put(DataSrc, acknowledged, PullDataMap);
         {_, undefined} ->
             lager:warning("pull_ack for unknown source"),
             PullDataMap;

--- a/test/hpr_protocol_gwmp_SUITE.erl
+++ b/test/hpr_protocol_gwmp_SUITE.erl
@@ -345,8 +345,22 @@ pull_ack_test(_Config) ->
 
     %% pull_data has been acked
     ok = test_utils:wait_until(fun() ->
-        0 == maps:size(element(6, sys:get_state(WorkerPid)))
+        [acknowledged] == maps:values(element(6, sys:get_state(WorkerPid)))
     end),
+
+    %% ===================================================================
+    %% Send another packet, there should not be another pull_data.
+    %% There's already a session started, and we'll send the pull_data on a cadence.
+
+    %% Sending the same packet again shouldn't matter here, we only want to
+    %% trigger the push_data/pull_data logic.
+    hpr_protocol_gwmp:send(PacketUp, unused_test_stream_handler, Route),
+
+    ?assertEqual(
+        #{{{127, 0, 0, 1}, 1777} => acknowledged},
+        element(6, sys:get_state(WorkerPid)),
+        "0 outstanding pull_data"
+    ),
 
     ok.
 
@@ -397,7 +411,7 @@ pull_ack_hostname_test(_Config) ->
 
     %% pull_data has been acked
     ok = test_utils:wait_until(fun() ->
-        0 == maps:size(element(6, sys:get_state(WorkerPid)))
+        [acknowledged] == maps:values(element(6, sys:get_state(WorkerPid)))
     end),
 
     %% ensure url was resolved


### PR DESCRIPTION
Keep the fact that a pull_data was acknowledged.

When a packet was sent, the worker would check to see if a pull_data had
been sent to the dest. That map is was checking only stored in-flight
pull_data. As soon as a pull_ack came through (normally immediate), the
worker would lose the ability to know if there was already a pull_data
session in tact with a specific destination.

The result was a new 10s pull_data timer being started every time a
packet was pushed.

Now, we keep the dest in the pull_data map and mark it as acknowledged.
The next pull_data will come and overwrite the entry.
