### PR TITLE
glue 1

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -54,7 +54,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.17.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"01c55bcc3850a8e8bffa392d9ee6f311f53d485a"}},
+       {ref,"73c27f70f5fe0839856eb4e9383a16eff735edfa"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},2},
  {<<"http2_client">>,

--- a/src/grpc/iot_config/hpr_route.erl
+++ b/src/grpc/iot_config/hpr_route.erl
@@ -14,7 +14,8 @@
     lns/1,
     gwmp_region_lns/2,
     md/1,
-    new_packet_router/2
+    new_packet_router/2,
+    is_valid_record/1
 ]).
 
 -export([
@@ -130,6 +131,10 @@ md(Route) ->
         {net_id, hpr_utils:int_to_hex(hpr_route:net_id(Route))},
         {lns, erlang:binary_to_list(hpr_route:lns(Route))}
     ].
+
+-spec is_valid_record(route()) -> boolean().
+is_valid_record(#iot_config_route_v1_pb{}) -> true;
+is_valid_record(_) -> false.
 
 -spec new_packet_router(Host :: string(), Port :: non_neg_integer() | string()) -> route().
 new_packet_router(Host, Port) when is_list(Port) ->
@@ -418,6 +423,12 @@ protocol_test() ->
         {gwmp, #iot_config_protocol_gwmp_v1_pb{mapping = []}},
         ?MODULE:protocol(?MODULE:server(Route))
     ),
+    ok.
+
+is_valid_record_test() ->
+    Route = test_route(),
+    ?assert(?MODULE:is_valid_record(Route)),
+    ?assertNot(?MODULE:is_valid_record({invalid, route, record})),
     ok.
 
 test_route() ->

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -4,6 +4,7 @@
     init/0,
     insert/1,
     delete/1,
+    delete_all/0,
     lookup_devaddr/1,
     lookup_eui/2
 ]).
@@ -68,6 +69,13 @@ delete(Route) ->
     lager:info("deleted ~w DevAddr Entries, ~w EUIS Entries for ~s", [
         DevAddrEntries, EUISEntries, ID
     ]),
+    ok.
+
+-spec delete_all() -> ok.
+delete_all() ->
+    ets:delete_all_objects(?DEVADDRS_ETS),
+    ets:delete_all_objects(?EUIS_ETS),
+    ets:delete_all_objects(?ROUTE_ETS),
     ok.
 
 -spec lookup_devaddr(DevAddr :: non_neg_integer()) -> list(hpr_route:route()).

--- a/src/grpc/iot_config/hpr_route_stream_worker.erl
+++ b/src/grpc/iot_config/hpr_route_stream_worker.erl
@@ -135,6 +135,7 @@ handle_info(?INIT_STREAM, #state{conn_backoff = Backoff0} = State) ->
         {ok, Stream} ->
             lager:info("stream initialized"),
             {_, Backoff1} = backoff:succeed(Backoff0),
+            ok = hpr_route_ets:delete_all(),
             {noreply, State#state{stream = Stream, conn_backoff = Backoff1}};
         {error, undefined_channel} ->
             lager:error(

--- a/src/grpc/iot_config/hpr_route_stream_worker.erl
+++ b/src/grpc/iot_config/hpr_route_stream_worker.erl
@@ -270,7 +270,14 @@ open_backup_file(Path) ->
         {ok, Binary} ->
             try erlang:binary_to_term(Binary) of
                 Map when is_map(Map) ->
-                    {ok, Map};
+                    case lists:all(fun hpr_route:is_valid_record/1, maps:values(Map)) of
+                        true ->
+                            {ok, Map};
+                        false ->
+                            lager:error("could not parse route record, fixing"),
+                            ok = file:write_file(Path, erlang:term_to_binary(#{})),
+                            {ok, #{}}
+                    end;
                 _ ->
                     ok = file:write_file(Path, erlang:term_to_binary(#{})),
                     lager:warning("binary_to_term failed, fixing"),

--- a/src/protocols/http/hpr_http_roaming_downlink_stream_worker.erl
+++ b/src/protocols/http/hpr_http_roaming_downlink_stream_worker.erl
@@ -121,6 +121,14 @@ handle_info({trailers, _StreamID, Trailers}, State) ->
             {noreply, State}
     end;
 handle_info(
+    {'DOWN', _Ref, process, Pid, Reason},
+    #state{stream = #{stream_pid := Pid}, conn_backoff = Backoff0} = State
+) ->
+    {Delay, Backoff1} = backoff:fail(Backoff0),
+    lager:info("stream went down from the other side for ~p, sleeping ~wms", [Reason, Delay]),
+    _ = erlang:send_after(Delay, self(), ?INIT_STREAM),
+    {noreply, State#state{stream = undefined, conn_backoff = Backoff1}};
+handle_info(
     {eos, StreamID},
     #state{stream = #{stream_id := StreamID}, conn_backoff = Backoff0} = State
 ) ->


### PR DESCRIPTION
When a connection is made to config service, remove all the backup routes. This keeps routes that were deleted while there was no connection from existing forever.

Go back to handling `DOWN` messages from streams. If a server dies, it does not always have time to send `eos` messages.