### PR TITLE
move stream monitoring to after worker has started

### DIFF
--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -139,7 +139,7 @@ handle_info({monitor_stream, AttemptCnt}, #state{pubkeybin = PubKeyBin} = State)
         {?MONITOR_STREAM_MAX_ATTEMPT, _} ->
             lager:info(MD, "monitor stream failed at max attempt"),
             {stop, max_monitor_attempt, State};
-        {error, not_found} ->
+        {_, {error, not_found}} ->
             lager:info(MD, "monitor stream failed"),
             erlang:send_after(?MONITOR_STREAM_TIMEOUT, self(), {monitor_stream, AttemptCnt + 1}),
             {noreply, State}


### PR DESCRIPTION
The registering of a stream has around 1 minute of trying to monitor before the worker will assume the stream is probably dead and stop itself.