### PR TITLE
upload packet reports with mime-type application/octet-stream

### DIFF
--- a/src/hpr_packet_reporter.erl
+++ b/src/hpr_packet_reporter.erl
@@ -225,7 +225,8 @@ upload(
             Bucket,
             FileName,
             #{
-                <<"Body">> => lists:reverse([Last | Packets])
+                <<"Body">> => lists:reverse([Last | Packets]),
+                <<"ContentType">> => <<"application/octet-stream">>
             }
         )
     of


### PR DESCRIPTION
match the default upload type in rust
https://docs.rs/aws-sdk-s3/0.21.0/src/aws_sdk_s3/input.rs.html#19660-19665