### PR TITLE
Don't dump the routing ets tables until we start receiving data from

### DIFF
--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -87,7 +87,7 @@ init_per_testcase(TestCase, Config) ->
 
     ok = test_utils:wait_until(
         fun() ->
-            {state, Stream, _Backoff} = sys:get_state(hpr_route_stream_worker),
+            {state, Stream, _Backoff, _} = sys:get_state(hpr_route_stream_worker),
             Stream =/= undefined andalso
                 erlang:is_pid(erlang:whereis(hpr_test_iot_config_service_route))
         end,


### PR DESCRIPTION
config service