### PR TITLE
process leak

### DIFF
--- a/src/grpc/packet_router/hpr_packet_report.erl
+++ b/src/grpc/packet_router/hpr_packet_report.erl
@@ -251,7 +251,7 @@ new_test() ->
             payload_hash => PHash,
             payload_size => PSize
         }),
-        ?MODULE:new(TestPacket, TestRoute)
+        ?MODULE:new(TestPacket, TestRoute, false, Now)
     ).
 
 -endif.

--- a/src/grpc/packet_router/hpr_packet_router_service.erl
+++ b/src/grpc/packet_router/hpr_packet_router_service.erl
@@ -33,12 +33,7 @@ route(eos, StreamState) ->
 route(EnvUp, StreamState) ->
     try hpr_envelope_up:data(EnvUp) of
         {packet, PacketUp} ->
-            _ = erlang:spawn_opt(
-                hpr_routing,
-                handle_packet,
-                [PacketUp],
-                [link, {fullsweep_after, 0}]
-            ),
+            _ = erlang:spawn_opt(hpr_routing, handle_packet, [PacketUp], [{fullsweep_after, 0}]),
             {ok, StreamState};
         {register, Reg} ->
             PubKeyBin = hpr_register:gateway(Reg),

--- a/src/grpc/packet_router/hpr_packet_router_service.erl
+++ b/src/grpc/packet_router/hpr_packet_router_service.erl
@@ -33,8 +33,18 @@ route(eos, StreamState) ->
 route(EnvUp, StreamState) ->
     try hpr_envelope_up:data(EnvUp) of
         {packet, PacketUp} ->
-            _ = erlang:spawn_opt(hpr_routing, handle_packet, [PacketUp], [{fullsweep_after, 0}]),
-            {ok, StreamState};
+            PubKeyBin = hpr_packet_up:gateway(PacketUp),
+            case ?MODULE:locate(PubKeyBin) of
+                {ok, _} ->
+                    _ = erlang:spawn_opt(hpr_routing, handle_packet, [PacketUp], [
+                        link,
+                        {fullsweep_after, 0}
+                    ]),
+                    {ok, StreamState};
+                {error, not_found} ->
+                    lager:warning("not accepting packet from unregistered"),
+                    {ok, StreamState}
+            end;
         {register, Reg} ->
             PubKeyBin = hpr_register:gateway(Reg),
             lager:md([{gateway, hpr_utils:gateway_name(PubKeyBin)}]),
@@ -103,6 +113,7 @@ register(PubKeyBin) ->
         {error, not_found} ->
             true = gproc:add_local_name(?REG_KEY(PubKeyBin)),
             lager:debug("register"),
+            hpr_protocol_router:register(PubKeyBin),
             ok;
         {ok, Self} ->
             lager:info("nothing to do, already registered"),

--- a/src/hpr.app.src
+++ b/src/hpr.app.src
@@ -31,6 +31,7 @@
         gproc,
         backoff
     ]},
+    {included_applications, [grpcbox, erlang_lorawan]},
     {env, []},
     {modules, []},
     {licenses, ["Apache 2.0"]},

--- a/src/hpr_app.erl
+++ b/src/hpr_app.erl
@@ -16,9 +16,12 @@ start(_StartType, _StartArgs) ->
             Error;
         OK ->
             hpr_cli_registry:register_cli(),
+            {ok, _} = application:ensure_all_started(grpcbox),
             OK
     end.
 
 stop(_State) ->
     lager:info("stopping app"),
+    %% TODO: This hangs indefinitely in ct tests, unsure why
+    %% _ = catch application:stop(grpcbox),
     ok.

--- a/src/hpr_routing.erl
+++ b/src/hpr_routing.erl
@@ -228,28 +228,32 @@ maybe_deliver_no_routes(Packet) ->
     Routes :: [{hpr_route:route(), non_neg_integer()}]
 ) -> {non_neg_integer(), boolean()}.
 maybe_deliver_packet_to_routes(Packet, Routes) ->
-    maybe_deliver_packet_to_routes(Packet, Routes, {0, false}).
-
--spec maybe_deliver_packet_to_routes(
-    Packet :: hpr_packet_up:packet(),
-    Routes :: [{hpr_route:route(), non_neg_integer()}],
-    {Routed :: non_neg_integer(), IsFree :: boolean()}
-) -> {Routed :: non_neg_integer(), IsFree :: boolean()}.
-maybe_deliver_packet_to_routes(_Packet, [], {Routed, IsFree}) ->
-    {Routed, IsFree};
-maybe_deliver_packet_to_routes(Packet, [{Route, SKFMaxCopies} | Routes], {Routed, true}) ->
-    case maybe_deliver_packet_to_route(Packet, Route, SKFMaxCopies) of
-        {ok, _IsFree} ->
-            maybe_deliver_packet_to_routes(Packet, Routes, {Routed + 1, true});
-        {error, _} ->
-            maybe_deliver_packet_to_routes(Packet, Routes, {Routed, true})
-    end;
-maybe_deliver_packet_to_routes(Packet, [{Route, SKFMaxCopies} | Routes], {Routed, false}) ->
-    case maybe_deliver_packet_to_route(Packet, Route, SKFMaxCopies) of
-        {ok, IsFree} ->
-            maybe_deliver_packet_to_routes(Packet, Routes, {Routed + 1, IsFree});
-        {error, _} ->
-            maybe_deliver_packet_to_routes(Packet, Routes, {Routed, false})
+    case erlang:length(Routes) of
+        1 ->
+            [{Route, SKFMaxCopies}] = Routes,
+            case maybe_deliver_packet_to_route(Packet, Route, SKFMaxCopies) of
+                {ok, IsFree} -> {1, IsFree};
+                {error, _} -> {0, false}
+            end;
+        X when X > 1 ->
+            MaybeDelivered = hpr_utils:pmap(
+                fun({Route, SKFMaxCopies}) ->
+                    maybe_deliver_packet_to_route(Packet, Route, SKFMaxCopies)
+                end,
+                Routes
+            ),
+            lists:foldl(
+                fun
+                    ({ok, _}, {Routed, true}) ->
+                        {Routed + 1, true};
+                    ({ok, IsFree}, {Routed, false}) ->
+                        {Routed + 1, IsFree};
+                    ({error, _}, {Routed, IsFree}) ->
+                        {Routed, IsFree}
+                end,
+                {0, false},
+                MaybeDelivered
+            )
     end.
 
 -spec maybe_deliver_packet_to_route(

--- a/src/protocols/hpr_protocol_router.erl
+++ b/src/protocols/hpr_protocol_router.erl
@@ -10,7 +10,8 @@
     init/0,
     send/2,
     get_stream/3,
-    remove_stream/2
+    remove_stream/2,
+    register/1
 ]).
 
 %% ------------------------------------------------------------------
@@ -41,7 +42,7 @@
 -define(CLEANUP_TIME, timer:seconds(30)).
 -endif.
 
--record(state, {}).
+-record(state, {waiting_cleanups :: map()}).
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
@@ -97,13 +98,17 @@ remove_stream(Gateway, LNS) ->
             ok
     end.
 
+-spec register(PubKeyBin :: binary()) -> ok.
+register(PubKeyBin) ->
+    gen_server:cast(?MODULE, {register, PubKeyBin}).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 
 init(_Args) ->
-    lager:info("~p started", [?MODULE]),
-    {ok, #state{}}.
+    lager:debug("~p started", [?MODULE]),
+    {ok, #state{waiting_cleanups = #{}}}.
 
 -spec handle_call(Msg, _From, #state{}) -> {stop, {unimplemented_call, Msg}, #state{}}.
 handle_call(Msg, _From, State) ->
@@ -112,19 +117,42 @@ handle_call(Msg, _From, State) ->
 
 handle_cast({monitor, Gateway, LNS, Pid}, State) ->
     _ = erlang:monitor(process, Pid, [{tag, {'DOWN', Gateway, LNS}}]),
-    lager:debug("monitoring gateway stream ~p", [Pid]),
+    Name = hpr_utils:gateway_name(Gateway),
+    lager:debug("monitoring gateway stream ~s ~p", [Name, Pid]),
     {noreply, State};
+handle_cast({register, PubKeyBin}, #state{waiting_cleanups = WaitingCleanups0} = State) ->
+    WaitingCleanups1 =
+        case maps:take(PubKeyBin, WaitingCleanups0) of
+            error ->
+                WaitingCleanups0;
+            {CleanupTimerRef, NewMap} ->
+                TimeLeft = erlang:cancel_timer(CleanupTimerRef),
+                lager:info(
+                    [{time_left_ms, TimeLeft}],
+                    "gw registered while waiting to take down streams"
+                ),
+                NewMap
+        end,
+    {noreply, State#state{waiting_cleanups = WaitingCleanups1}};
 handle_cast(_Msg, State) ->
     lager:warning("unknown cast ~p", [_Msg]),
     {noreply, State}.
 
 handle_info(
     {{'DOWN', Gateway, LNS}, _Monitor, process, _Pid, _ExitReason},
-    #state{} = State
+    #state{waiting_cleanups = WaitingCleanups} = State
 ) ->
-    lager:debug("gateway stream ~p went down: ~p waiting ~wms", [_Pid, _ExitReason, ?CLEANUP_TIME]),
-    ok = maybe_trigger_cleanup(Gateway, LNS),
-    {noreply, State};
+    Name = hpr_utils:gateway_name(Gateway),
+    lager:debug("gateway ~s stream ~p went down: ~p waiting ~wms", [
+        Name, _Pid, _ExitReason, ?CLEANUP_TIME
+    ]),
+    CleanupTimer = erlang:send_after(?CLEANUP_TIME, self(), {remove_stream, Gateway}),
+    {noreply, State#state{waiting_cleanups = WaitingCleanups#{Gateway => CleanupTimer}}};
+handle_info({remove_stream, Gateway}, #state{waiting_cleanups = WaitingCleanups} = State) ->
+    Name = hpr_utils:gateway_name(Gateway),
+    lager:debug([{gateway, Name}], "removing streams"),
+    ?MODULE:remove_stream(Gateway),
+    {noreply, State#state{waiting_cleanups = maps:without([Gateway], WaitingCleanups)}};
 handle_info(_Msg, State) ->
     lager:warning("unknown info ~p", [_Msg]),
     {noreply, State}.
@@ -135,6 +163,52 @@ terminate(_Reason, _State = #state{}) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
+
+-spec maybe_trigger_monitor(Gateway :: libp2p_crypto:pubkey_bin(), LNS :: binary()) -> ok.
+maybe_trigger_monitor(Gateway, LNS) ->
+    Name = hpr_utils:gateway_name(Gateway),
+    lager:debug("~p :: ~p", [?FUNCTION_NAME, Name]),
+    erlang:spawn(fun() ->
+        case hpr_packet_router_service:locate(Gateway) of
+            {ok, Pid} ->
+                ok = gen_server:cast(?MODULE, {monitor, Gateway, LNS, Pid});
+            {error, _Reason} ->
+                lager:debug(
+                    "failed to monitor gateway (~s) stream for lns (~s) ~p",
+                    [
+                        hpr_utils:gateway_name(Gateway), LNS, _Reason
+                    ]
+                ),
+                %% Instead of doing a remove_stream, we trigger a maybe cleaup, we dont kill
+                %% the stream to Router right away so if a downlink comes back and
+                %% the gateway reconnected we can still send that downlink
+                ok = maybe_trigger_cleanup(Gateway, LNS)
+        end
+    end),
+    ok.
+
+-spec maybe_trigger_cleanup(Gateway :: libp2p_crypto:pubkey_bin(), LNS :: binary()) -> pid().
+maybe_trigger_cleanup(Gateway, LNS) ->
+    Name = hpr_utils:gateway_name(Gateway),
+    lager:debug("~p :: ~p", [?FUNCTION_NAME, Name]),
+    erlang:spawn(fun() ->
+        timer:sleep(10000),
+        lager:debug("checking for ~p in ~pms", [Name, 20000]),
+        timer:sleep(10000),
+        lager:debug("checking for ~p in ~pms", [Name, 10000]),
+        timer:sleep(10000),
+        lager:debug("checking for ~p now", [Name]),
+        case hpr_packet_router_service:locate(Gateway) of
+            {error, _Reason} ->
+                lager:debug("connot find a gateway stream: ~p, shutting down", [_Reason]),
+                ?MODULE:remove_stream(Gateway, LNS);
+            {ok, NewPid} ->
+                ok = gen_server:cast(?MODULE, {monitor, Gateway, LNS, NewPid}),
+                lager:debug("monitoring new gateway stream ~p", [NewPid])
+        end
+    end).
+%% ,
+%% ok.
 
 -spec get_stream(
     Gateway :: libp2p_crypto:pubkey_bin(),
@@ -245,6 +319,7 @@ connect(LNS, Server) ->
     case grpcbox_channel:pick(LNS, stream) of
         %% No connection, lets try to connect
         {error, _} ->
+            lager:debug("connecting for the first time: ~p", [LNS]),
             Host = hpr_route:host(Server),
             Port = hpr_route:port(Server),
             case
@@ -259,42 +334,6 @@ connect(LNS, Server) ->
         {ok, {_Conn, _Interceptor}} ->
             ok
     end.
-
--spec maybe_trigger_monitor(Gateway :: libp2p_crypto:pubkey_bin(), LNS :: binary()) -> ok.
-maybe_trigger_monitor(Gateway, LNS) ->
-    erlang:spawn(fun() ->
-        case hpr_packet_router_service:locate(Gateway) of
-            {ok, Pid} ->
-                ok = gen_server:cast(?MODULE, {monitor, Gateway, LNS, Pid});
-            {error, _Reason} ->
-                lager:debug(
-                    "failed to monitor gateway (~s) stream for lns (~s) ~p",
-                    [
-                        hpr_utils:gateway_name(Gateway), LNS, _Reason
-                    ]
-                ),
-                %% Instead of doing a remove_stream, we trigger a maybe cleaup, we dont kill
-                %% the stream to Router right away so if a downlink comes back and
-                %% the gateway reconnected we can still send that downlink
-                ok = maybe_trigger_cleanup(Gateway, LNS)
-        end
-    end),
-    ok.
-
--spec maybe_trigger_cleanup(Gateway :: libp2p_crypto:pubkey_bin(), LNS :: binary()) -> ok.
-maybe_trigger_cleanup(Gateway, LNS) ->
-    erlang:spawn(fun() ->
-        timer:sleep(?CLEANUP_TIME),
-        case hpr_packet_router_service:locate(Gateway) of
-            {error, _Reason} ->
-                lager:debug("connot find a gateway stream: ~p, shutting down", [_Reason]),
-                ?MODULE:remove_stream(Gateway, LNS);
-            {ok, NewPid} ->
-                ok = gen_server:cast(?MODULE, {monitor, Gateway, LNS, NewPid}),
-                lager:debug("monitoring new gateway stream ~p", [NewPid])
-        end
-    end),
-    ok.
 
 %% ------------------------------------------------------------------
 %% Tests Functions

--- a/src/protocols/hpr_protocol_router.erl
+++ b/src/protocols/hpr_protocol_router.erl
@@ -53,7 +53,9 @@ start_link(Args) ->
 
 -spec init() -> ok.
 init() ->
-    ?STREAM_ETS = ets:new(?STREAM_ETS, [public, named_table, set, {read_concurrency, true}]),
+    ?STREAM_ETS = ets:new(?STREAM_ETS, [
+        public, named_table, set, {read_concurrency, true}, {write_concurrency, true}
+    ]),
     ok.
 
 -spec send(


### PR DESCRIPTION
- ~~link to packet delivery spawns.~~
- ~~update proto.~~
- move `grpcbox` to an `included_application`.
  - This keeps grpcbox from starting and accepting traffic until `hpr` is fully booted and decides to start `grpcbox` in `hpr_app.erl`.
 - Rework how router protocol monitors streams.
   - Monitor at the incoming stream level, when that goes down start a timer to remove all outgoing streams.
   - A gateway re-registering can cancel the timer and it will re-use the existing streams.
   - The server side of an outgoing stream can still close and remove a stream.