### PR TITLE
routing by packet lookup

### DIFF
--- a/config/ct.config
+++ b/config/ct.config
@@ -22,7 +22,9 @@
             host => "localhost",
             port => "8087"
         }},
-        {multi_buy_enabled, true}
+        {multi_buy_enabled, true},
+        {routing_cleanup_timer_secs, 1},
+        {routing_cleanup_window_secs, 1}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env]},

--- a/config/ct.config
+++ b/config/ct.config
@@ -23,8 +23,8 @@
             port => "8087"
         }},
         {multi_buy_enabled, true},
-        {routing_cleanup_timer_secs, 1},
-        {routing_cleanup_window_secs, 1}
+        {routing_cache_window_secs, 5},
+        {routing_cache_timeout_secs, 10}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env]},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -24,8 +24,8 @@
             host => "${HPR_MULTI_BUY_SERVICE_HOST}",
             port => "${HPR_MULTI_BUY_SERVICE_PORT}"
         }},
-        {routing_cleanup_timer_secs, 15},
-        {routing_cleanup_window_secs, 120}
+        {routing_cache_timeout_secs, 15},
+        {routing_cache_window_secs, 120}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env, aws_credentials_ec2]}

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -23,7 +23,9 @@
             transport => "${HPR_MULTI_BUY_SERVICE_TRANSPORT}",
             host => "${HPR_MULTI_BUY_SERVICE_HOST}",
             port => "${HPR_MULTI_BUY_SERVICE_PORT}"
-        }}
+        }},
+        {routing_cleanup_timer_secs, 15},
+        {routing_cleanup_window_secs, 120}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env, aws_credentials_ec2]}

--- a/src/cli/hpr_cli_config.erl
+++ b/src/cli/hpr_cli_config.erl
@@ -290,8 +290,8 @@ config_skf(["config", "skf", DevAddrOrSKF], [], []) ->
                         RouteID = hpr_route:id(Route),
                         ETS = hpr_route_ets:skf_ets(RouteETS),
                         [
-                            {DevAddr, SK, RouteID, LastUsed * -1, MaxCopies}
-                         || {SK, LastUsed, MaxCopies} <- hpr_route_ets:lookup_skf(ETS, DevAddr)
+                            {DevAddr, SK, RouteID, MaxCopies}
+                         || {SK, MaxCopies} <- hpr_route_ets:lookup_skf(ETS, DevAddr)
                         ] ++ Acc
                     end,
                     [],
@@ -305,11 +305,10 @@ config_skf(["config", "skf", DevAddrOrSKF], [], []) ->
         [] ->
             c_text("No SKF found for ~p", [DevAddrOrSKF]);
         SKFs ->
-            MkRow = fun({DevAddr, SK, RouteID, LastUsed, MaxCopies}) ->
+            MkRow = fun({DevAddr, SK, RouteID, MaxCopies}) ->
                 [
                     {" Route ID ", RouteID},
                     {" Session Key ", hpr_utils:bin_to_hex_string(SK)},
-                    {" Last Used ", LastUsed},
                     {" Max Copies ", MaxCopies},
                     {" DevAddr ", hpr_utils:int_to_hex_string(DevAddr)}
                 ]

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -361,7 +361,7 @@ delete_skf(SKF) ->
             DevAddr = hpr_skf:devaddr(SKF),
             SessionKey = hpr_skf:session_key(SKF),
             MaxCopies = hpr_skf:max_copies(SKF),
-            %% Here we ignore max_copies
+
             true = ets:delete(SKFETS, hpr_utils:hex_to_bin(SessionKey)),
             lager:debug(
                 [

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -23,7 +23,6 @@
     lookup_devaddr_range/1,
 
     insert_skf/1,
-    insert_new_skf/1,
     update_skf/4,
     delete_skf/1,
     lookup_skf/2,
@@ -317,21 +316,6 @@ insert_skf(SKF) ->
             lager:debug(MD, "updated SKF");
         _Other ->
             lager:error(MD, "failed to insert skf table not found ~p", [
-                _Other
-            ])
-    end,
-    ok.
-
--spec insert_new_skf(SKF :: hpr_skf:skf()) -> ok.
-insert_new_skf(SKF) ->
-    RouteID = hpr_skf:route_id(SKF),
-    MD = skf_md(RouteID, SKF),
-    case ?MODULE:lookup_route(RouteID) of
-        [#hpr_route_ets{skf_ets = SKFETS}] ->
-            do_insert_skf(SKFETS, SKF),
-            lager:debug(MD, "inserted SKF");
-        _Other ->
-            lager:error(MD, "failed to insert new skf, tabl not found ~p", [
                 _Other
             ])
     end,

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -382,7 +382,7 @@ delete_skf(SKF) ->
 -spec lookup_skf(ETS :: ets:table(), DevAddr :: non_neg_integer()) ->
     [{SessionKey :: binary(), MaxCopies :: non_neg_integer()}].
 lookup_skf(ETS, DevAddr) ->
-    MS = [{{'$2', {DevAddr, '$3'}}, [], [{{'$2', '$3'}}]}],
+    MS = [{{'$1', {DevAddr, '$2'}}, [], [{{'$1', '$2'}}]}],
     ets:select(ETS, MS).
 
 -spec select_skf(Continuation :: ets:continuation()) ->
@@ -394,7 +394,7 @@ select_skf(Continuation) ->
     {[{SessionKey :: binary(), MaxCopies :: non_neg_integer()}], ets:continuation()}
     | '$end_of_table'.
 select_skf(ETS, DevAddr) ->
-    MS = [{{'$2', {DevAddr, '$3'}}, [], [{{'$2', '$3'}}]}],
+    MS = [{{'$1', {DevAddr, '$2'}}, [], [{{'$1', '$2'}}]}],
     ets:select(ETS, MS, 100).
 
 -spec delete_all() -> ok.

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -380,9 +380,9 @@ delete_skf(SKF) ->
     ok.
 
 -spec lookup_skf(ETS :: ets:table(), DevAddr :: non_neg_integer()) ->
-    [{SessionKey :: binary(), Timestamp :: integer(), MaxCopies :: non_neg_integer()}].
+    [{SessionKey :: binary(), MaxCopies :: non_neg_integer()}].
 lookup_skf(ETS, DevAddr) ->
-    MS = [{{'$2', {DevAddr, '$3'}}, [], [{{'$2', -1, '$3'}}]}],
+    MS = [{{'$2', {DevAddr, '$3'}}, [], [{{'$2', '$3'}}]}],
     ets:select(ETS, MS).
 
 -spec select_skf(Continuation :: ets:continuation()) ->
@@ -391,9 +391,9 @@ select_skf(Continuation) ->
     ets:select(Continuation).
 
 -spec select_skf(ETS :: ets:table(), DevAddr :: non_neg_integer() | ets:continuation()) ->
-    {[{binary(), integer(), non_neg_integer()}], ets:continuation()} | '$end_of_table'.
+    {[{SessionKey :: binary(), MaxCopies :: non_neg_integer()}], ets:continuation()} | '$end_of_table'.
 select_skf(ETS, DevAddr) ->
-    MS = [{{'$2', {DevAddr, '$3'}}, [], [{{'$2', -1, '$3'}}]}],
+    MS = [{{'$2', {DevAddr, '$3'}}, [], [{{'$2', '$3'}}]}],
     ets:select(ETS, MS, 100).
 
 -spec delete_all() -> ok.

--- a/src/hpr_multi_buy.erl
+++ b/src/hpr_multi_buy.erl
@@ -6,7 +6,8 @@
 -export([
     init/0,
     update_counter/2,
-    cleanup/1
+    cleanup/1,
+    make_key/2
 ]).
 
 -define(ETS, hpr_multi_buy_ets).
@@ -69,6 +70,13 @@ cleanup(Duration) ->
         lager:debug("expiring ~w keys", [Deleted])
     end),
     ok.
+
+-spec make_key(hpr_packet_up:packet(), hpr_route:route()) -> binary().
+make_key(PacketUp, Route) ->
+    crypto:hash(sha256, <<
+        (hpr_packet_up:phash(PacketUp))/binary,
+        (hpr_route:lns(Route))/binary
+    >>).
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/src/hpr_routing.erl
+++ b/src/hpr_routing.erl
@@ -115,7 +115,7 @@ establish_routing(PacketUp, Start) ->
 
 -spec do_routing(
     PacketUp :: hpr_packet_up:packet(),
-    RouteETS :: hpr_route_ets:route(),
+    [{RouteETS :: hpr_route_ets:route(), SKFMaxCopies :: non_neg_integer()}],
     StartTime :: non_neg_integer()
 ) -> ok.
 do_routing(PacketUp, RoutesETS, Start) ->

--- a/src/hpr_routing.erl
+++ b/src/hpr_routing.erl
@@ -303,9 +303,7 @@ maybe_deliver_packet_to_route(PacketUp, RouteETS, SKFMaxCopies) ->
         {true, false, _} ->
             Server = hpr_route:server(Route),
             Protocol = hpr_route:protocol(Server),
-            Key = crypto:hash(sha256, <<
-                (hpr_packet_up:phash(PacketUp))/binary, (hpr_route:lns(Route))/binary
-            >>),
+            Key = hpr_multi_buy:make_key(PacketUp, Route),
             MaxCopies =
                 case SKFMaxCopies of
                     0 -> hpr_route:max_copies(Route);

--- a/src/hpr_routing_cache.erl
+++ b/src/hpr_routing_cache.erl
@@ -175,12 +175,12 @@ do_crawl_routing(Window) ->
     Now = erlang:system_time(millisecond) - Window,
     %% MS = ets:fun2ms(fun(#routing_entry{time = Time}) when Time < 1234 -> true end).
     MS = [{
-        #routing_entry{
-            hash = '_',
-            time = '$1',
-            state = '_',
-            routes = '_',
-            packets = '_'
+        {routing_entry,
+            '_',
+            '$1',
+            '_',
+            '_',
+            '_'
         },
         [{'<', '$1', Now}],
         [true]

--- a/src/hpr_routing_cache.erl
+++ b/src/hpr_routing_cache.erl
@@ -1,0 +1,188 @@
+-module(hpr_routing_cache).
+
+-behaviour(gen_server).
+
+%% ------------------------------------------------------------------
+%% API Function Exports
+%% ------------------------------------------------------------------
+-export([
+    start_link/1,
+    init_ets/0
+]).
+
+-export([
+    lookup/1,
+    queue/2,
+    lock/2,
+    error/2,
+    no_routes/1,
+    routes/2
+]).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Exports
+%% ------------------------------------------------------------------
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-define(SERVER, ?MODULE).
+-define(ROUTING_ETS, hpr_routing_cache_ets).
+-define(CLEANUP, cleanup_tick).
+
+-type packet() :: {hpr_packet_up:packet(), Time :: non_neg_integer()}.
+
+-record(state, {
+    window :: non_neg_integer(),
+    timeout :: non_neg_integer(),
+    timer_ref :: reference()
+}).
+
+-record(routing_entry, {
+    hash :: binary(),
+    time :: non_neg_integer(),
+    state :: route | no_routes | locked | {error, any()},
+    routes = [] :: list(hpr_route_ets:route()),
+    packets = [] :: list(packet())
+}).
+
+%% ------------------------------------------------------------------
+%% ETS Function Definitions
+%% ------------------------------------------------------------------
+
+init_ets() ->
+    ?ROUTING_ETS = ets:new(?ROUTING_ETS, [
+        public,
+        named_table,
+        set,
+        {write_concurrency, true},
+        {read_concurrency, true},
+        {keypos, #routing_entry.hash}
+    ]),
+    ok.
+
+-spec lookup(binary()) ->
+    new
+    | no_routes
+    | {route, list(hpr_route_ets:route())}
+    | {locked, #routing_entry{}}
+    | {error, any()}.
+lookup(Hash) ->
+    case ets:lookup(?ROUTING_ETS, Hash) of
+        [] -> new;
+        [#routing_entry{state = no_routes}] -> no_routes;
+        [#routing_entry{state = route, routes = Routes}] -> {route, Routes};
+        [#routing_entry{state = locked} = Entry] -> {locked, Entry};
+        [#routing_entry{state = {error, _} = Err}] -> Err
+    end.
+
+-spec queue(#routing_entry{}, packet()) -> ok.
+queue(#routing_entry{packets = Packets} = Entry, NewPacket) ->
+    ets:insert(?ROUTING_ETS, Entry#routing_entry{packets = [NewPacket | Packets]}),
+    ok.
+
+-spec lock(hpr_packet_up:packet(), StartTime :: non_neg_integer()) ->
+    {ok, #routing_entry{}} | {error, already_locked}.
+lock(PacketUp, StartTime) ->
+    Entry = #routing_entry{
+        hash = hpr_packet_up:phash(PacketUp),
+        time = StartTime,
+        state = locked,
+        packets = [{PacketUp, StartTime}]
+    },
+    case ets:insert_new(?ROUTING_ETS, Entry) of
+        true -> {ok, Entry};
+        false -> {error, already_locked}
+    end.
+
+-spec error(#routing_entry{}, {error, any()}) -> ok.
+error(Entry, Error) ->
+    ets:insert(?ROUTING_ETS, Entry#routing_entry{state = Error}),
+    ok.
+
+-spec no_routes(#routing_entry{}) -> ok.
+no_routes(Entry) ->
+    ets:insert(?ROUTING_ETS, Entry#routing_entry{state = no_routes}),
+    ok.
+
+-spec routes(#routing_entry{}, list(hpr_routing:route())) -> list(packet()).
+routes(#routing_entry{hash = Hash} = Entry, RoutesETS) ->
+    case ?MODULE:lookup(Hash) of
+        {locked, #routing_entry{packets = QueuedPackets}} ->
+            ets:insert(?ROUTING_ETS, Entry#routing_entry{state = route, routes = RoutesETS}),
+            QueuedPackets;
+        Other ->
+            lager:warning(
+                [{hash, Hash}, {result, Other}],
+                "trying to apply routes to a non-locked entry, ignoring"
+            ),
+            []
+    end.
+
+%% ------------------------------------------------------------------
+%% API Function Definitions
+%% ------------------------------------------------------------------
+
+start_link(Args) ->
+    gen_server:start_link({local, ?SERVER}, ?SERVER, Args, []).
+
+%% ------------------------------------------------------------------
+%% gen_server Function Definitions
+%% ------------------------------------------------------------------
+
+init(_Args) ->
+    Window = hpr_utils:get_env_int(routing_cache_window_secs, 120),
+    Timeout = hpr_utils:get_env_int(routing_cache_timeout_secs, 15),
+    TRef = erlang:send_after(0, self(), ?CLEANUP),
+    {ok, #state{
+        window = timer:seconds(Window),
+        timeout = timer:seconds(Timeout),
+        timer_ref = TRef
+    }}.
+
+-spec handle_call(Msg, _From, #state{}) -> {stop, {unimplemented_call, Msg}, #state{}}.
+handle_call(Msg, _From, State) ->
+    lager:warning("unknown call ~p", [Msg]),
+    {stop, {unimplemented_call, Msg}, State}.
+
+handle_cast(_Msg, State) ->
+    lager:warning("unknown cast ~p", [_Msg]),
+    {noreply, State}.
+
+handle_info(?CLEANUP, #state{window = Window, timeout = Timeout} = State) ->
+    {Time0, NumDeleted} = timer:tc(fun() -> do_crawl_routing(Window) end),
+    Time = erlang:convert_time_unit(Time0, microsecond, millisecond),
+    lager:debug([{duration, Time}, {deleted, NumDeleted}], "routing cache cleanup"),
+    TRef = erlang:send_after(Timeout, self(), ?CLEANUP),
+    {noreply, State#state{timer_ref = TRef}};
+handle_info(_Msg, State) ->
+    lager:warning("unknown info ~p", [_Msg]),
+    {noreply, State}.
+
+terminate(_Reason, _State = #state{}) ->
+    ok.
+
+%% ------------------------------------------------------------------
+%% Internal Function Definitions
+%% ------------------------------------------------------------------
+
+-spec do_crawl_routing(Window :: non_neg_integer()) -> NumDeleted :: non_neg_integer().
+do_crawl_routing(Window) ->
+    Now = erlang:system_time(millisecond) - Window,
+    %% MS = ets:fun2ms(fun(#routing_entry{time = Time}) when Time < 1234 -> true end).
+    MS = [{
+        #routing_entry{
+            hash = '_',
+            time = '$1',
+            state = '_',
+            routes = '_',
+            packets = '_'
+        },
+        [{'<', '$1', Now}],
+        [true]
+    }],
+    ets:select_delete(?ROUTING_ETS, MS).

--- a/src/hpr_sup.erl
+++ b/src/hpr_sup.erl
@@ -53,6 +53,7 @@ init([]) ->
     ok = filelib:ensure_dir(KeyFileName),
     ok = hpr_utils:load_key(KeyFileName),
 
+    ok = hpr_routing_cache:init_ets(),
     ok = hpr_routing:init(),
     ok = hpr_multi_buy:init(),
     ok = hpr_protocol_router:init(),
@@ -75,6 +76,7 @@ init([]) ->
     ],
 
     ChildSpecs = [
+        ?WORKER(hpr_routing_cache, [#{}]),
         ?WORKER(hpr_metrics, [#{}]),
         ?ELLI_WORKER(hpr_metrics_handler, [ElliConfigMetrics]),
 

--- a/src/hpr_utils.erl
+++ b/src/hpr_utils.erl
@@ -26,6 +26,7 @@
     pmap/2, pmap/4,
     enumerate_0/1,
     enumerate_last/1,
+    get_env_int/2,
     %%
     load_key/1,
     pubkey_bin/0,
@@ -219,6 +220,14 @@ enumerate_0(L) ->
 enumerate_last(L) ->
     Last = erlang:length(L),
     [{Idx + 1 == Last, El} || {Idx, El} <- enumerate_0(L)].
+
+-spec get_env_int(atom(), integer()) -> integer().
+get_env_int(Key, Default) ->
+    case application:get_env(hpr, Key, Default) of
+        [] -> Default;
+        Str when is_list(Str) -> erlang:list_to_integer(Str);
+        I -> I
+    end.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/test/hpr_route_stream_worker_SUITE.erl
+++ b/test/hpr_route_stream_worker_SUITE.erl
@@ -118,7 +118,7 @@ main_test(_Config) ->
     ?assertEqual([], hpr_route_ets:lookup_eui_pair(3, 3)),
     SK1 = hpr_utils:hex_to_bin(SessionKey1),
     ?assertMatch(
-        [{SK1, X, 1}] when X < 0, hpr_route_ets:lookup_skf(SKFETS1, DevAddr1)
+        [{SK1, 1}], hpr_route_ets:lookup_skf(SKFETS1, DevAddr1)
     ),
 
     %% Delete EUI Pairs / DevAddr Ranges / SKF
@@ -192,7 +192,7 @@ main_test(_Config) ->
     ?assertEqual([], hpr_route_ets:lookup_eui_pair(3, 3)),
     SK1 = hpr_utils:hex_to_bin(SessionKey1),
     ?assertMatch(
-        [{SK1, X, 1}] when X < 0, hpr_route_ets:lookup_skf(SKFETS1, DevAddr1)
+        [{SK1, 1}], hpr_route_ets:lookup_skf(SKFETS1, DevAddr1)
     ),
 
     %% Remove route should delete eveything
@@ -280,7 +280,7 @@ refresh_route_test(_Config) ->
     ?assertEqual([], hpr_route_ets:lookup_eui_pair(3, 3)),
     SK1 = hpr_utils:hex_to_bin(SessionKey1),
     ?assertMatch(
-        [{SK1, X, 1}] when X < 0, hpr_route_ets:lookup_skf(SKFETS1, DevAddr1)
+        [{SK1, 1}], hpr_route_ets:lookup_skf(SKFETS1, DevAddr1)
     ),
 
     %% ===================================================================
@@ -337,7 +337,7 @@ refresh_route_test(_Config) ->
     ?assertEqual([RouteETS2], hpr_route_ets:lookup_eui_pair(2, 100)),
     SK2 = hpr_utils:hex_to_bin(SessionKey2),
     ?assertMatch(
-        [{SK2, X, 1}] when X < 0, hpr_route_ets:lookup_skf(SKFETS2, DevAddr2)
+        [{SK2, 1}], hpr_route_ets:lookup_skf(SKFETS2, DevAddr2)
     ),
 
     %% ===================================================================

--- a/test/hpr_routing_SUITE.erl
+++ b/test/hpr_routing_SUITE.erl
@@ -1530,7 +1530,7 @@ routing_cleanup_test(_Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Gateway = libp2p_crypto:pubkey_to_bin(PubKey),
 
-    CleanupPid0 = hpr_routing:get_crawl_routing_pid(),
+    CleanupPid0 = whereis(routing_cleanup),
 
     meck:new(hpr_protocol_router, [passthrough]),
     meck:expect(hpr_protocol_router, send, fun(_, _) -> ok end),
@@ -1588,7 +1588,7 @@ routing_cleanup_test(_Config) ->
 
     %% Packets have been cleaned out
     ?assertEqual(0, ets:info(hpr_packet_routing_ets, size)),
-    CleanupPid1 = hpr_routing:get_crawl_routing_pid(),
+    CleanupPid1 = whereis(routing_cleanup),
 
     %% Cleanup has been run and different Pid resides.
     ?assertNotEqual(CleanupPid0, CleanupPid1),

--- a/test/hpr_routing_SUITE.erl
+++ b/test/hpr_routing_SUITE.erl
@@ -1530,8 +1530,6 @@ routing_cleanup_test(_Config) ->
     SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
     Gateway = libp2p_crypto:pubkey_to_bin(PubKey),
 
-    CleanupPid0 = whereis(routing_cleanup),
-
     meck:new(hpr_protocol_router, [passthrough]),
     meck:expect(hpr_protocol_router, send, fun(_, _) -> ok end),
 
@@ -1580,18 +1578,14 @@ routing_cleanup_test(_Config) ->
     meck:unload(hpr_protocol_router),
 
     %% 2 unique packets sent so far
-    ?assertEqual(2, ets:info(hpr_packet_routing_ets, size)),
+    ?assertEqual(2, ets:info(hpr_routing_cache_ets, size)),
 
     %% wait cleanup to happen one last time.
-    Waiting = 2 * hpr_utils:get_env_int(routing_cleanup_window_secs, 0),
+    Waiting = 2 * hpr_utils:get_env_int(routing_cache_window_secs, 0),
     timer:sleep(timer:seconds(Waiting)),
 
     %% Packets have been cleaned out
-    ?assertEqual(0, ets:info(hpr_packet_routing_ets, size)),
-    CleanupPid1 = whereis(routing_cleanup),
-
-    %% Cleanup has been run and different Pid resides.
-    ?assertNotEqual(CleanupPid0, CleanupPid1),
+    ?assertEqual(0, ets:info(hpr_routing_cache_ets, size)),
 
     ok.
 

--- a/test/hpr_routing_SUITE.erl
+++ b/test/hpr_routing_SUITE.erl
@@ -17,7 +17,6 @@
     wrong_gateway_test/1,
     bad_signature_test/1,
     mic_check_test/1,
-    skf_update_test/1,
     skf_max_copies_test/1,
     multi_buy_without_service_test/1,
     multi_buy_with_service_test/1,
@@ -48,7 +47,6 @@ all() ->
         wrong_gateway_test,
         bad_signature_test,
         mic_check_test,
-        skf_update_test,
         skf_max_copies_test,
         multi_buy_without_service_test,
         multi_buy_with_service_test,
@@ -291,63 +289,6 @@ mic_check_test(_Config) ->
     ),
 
     ?assertEqual(ok, hpr_routing:handle_packet(PacketUp(3), #{gateway => Gateway})),
-
-    ok.
-
-skf_update_test(_Config) ->
-    #{secret := PrivKey, public := PubKey} = libp2p_crypto:generate_keys(ed25519),
-    SigFun = libp2p_crypto:mk_sig_fun(PrivKey),
-    Gateway = libp2p_crypto:pubkey_to_bin(PubKey),
-
-    AppSessionKey = crypto:strong_rand_bytes(16),
-    NwkSessionKey = crypto:strong_rand_bytes(16),
-    DevAddr = 16#00000001,
-    PacketUp = test_utils:uplink_packet_up(#{
-        app_session_key => AppSessionKey,
-        nwk_session_key => NwkSessionKey,
-        devaddr => DevAddr,
-        gateway => Gateway,
-        sig_fun => SigFun
-    }),
-
-    Route = hpr_route:test_new(#{
-        id => "11ea6dfd-3dce-4106-8980-d34007ab689b",
-        net_id => 0,
-        oui => 1,
-        server => #{
-            host => "lns1.testdomain.com",
-            port => 80,
-            protocol => {http_roaming, #{}}
-        },
-        max_copies => 1
-    }),
-    RouteID = hpr_route:id(Route),
-    ?assertEqual(ok, hpr_route_ets:insert_route(Route)),
-
-    DevAddrRange = hpr_devaddr_range:test_new(#{
-        route_id => RouteID, start_addr => 16#00000000, end_addr => 16#0000000A
-    }),
-    ?assertEqual(ok, hpr_route_ets:insert_devaddr_range(DevAddrRange)),
-
-    SKF = hpr_skf:new(#{
-        route_id => RouteID,
-        devaddr => DevAddr,
-        session_key => hpr_utils:bin_to_hex_string(NwkSessionKey),
-        max_copies => 3
-    }),
-    ?assertEqual(ok, hpr_route_ets:insert_skf(SKF)),
-
-    [RouteETS] = hpr_route_ets:lookup_route(RouteID),
-    ETS = hpr_route_ets:skf_ets(RouteETS),
-
-    %% Here we are making sure that the SKF got updated
-    [{_, BeforeUpdate, 3}] = hpr_route_ets:lookup_skf(ETS, DevAddr),
-    timer:sleep(2000),
-    ?assertEqual(ok, hpr_routing:handle_packet(PacketUp, #{gateway => Gateway})),
-
-    [{_, AfterUpdate, 3}] = hpr_route_ets:lookup_skf(ETS, DevAddr),
-    %% This is due to time being negative for ets ordering
-    ?assertNot(AfterUpdate < BeforeUpdate, "no longer checking difference in skf timing"),
 
     ok.
 

--- a/test/hpr_routing_SUITE.erl
+++ b/test/hpr_routing_SUITE.erl
@@ -347,7 +347,7 @@ skf_update_test(_Config) ->
 
     [{_, AfterUpdate, 3}] = hpr_route_ets:lookup_skf(ETS, DevAddr),
     %% This is due to time being negative for ets ordering
-    ?assert(AfterUpdate < BeforeUpdate),
+    ?assertNot(AfterUpdate < BeforeUpdate, "no longer checking difference in skf timing"),
 
     ok.
 

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -88,7 +88,7 @@ init_per_testcase(TestCase, Config) ->
 
     ok = test_utils:wait_until(
         fun() ->
-            {state, Stream, _Backoff, _} = sys:get_state(hpr_route_stream_worker),
+            {state, Stream, _Backoff} = sys:get_state(hpr_route_stream_worker),
             Stream =/= undefined andalso
                 erlang:is_pid(erlang:whereis(hpr_test_iot_config_service_route))
         end,

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -270,8 +270,12 @@ wait_until(Fun, Retry, Delay) when Retry > 0 ->
     case Res of
         true ->
             ok;
+        {true, _} ->
+            ok;
         {fail, _Reason} = Fail ->
             Fail;
+        {false, Extra} when Retry == 1 ->
+            {fail, Extra};
         _ when Retry == 1 ->
             {fail, Res};
         _ ->


### PR DESCRIPTION
This PR changes the way packets get their routing determined, for the purpose of having more freedom in how we store SessionKey Filters.

### The when of packets
The first time a packet is see, we take a lock on the phash and start finding if it's routable.
Any packets that come in during that time will queue themselves.
Once the routing is figured out, the initial packet, and all the queued packets are routed, and the routing information is put into ETS.
Any packet coming along after routing has been determined will immediately retrieve it's routes.

Multi-buy is always checked.

### But there's a lot of changes to SKF storage...
The last_used timestamp for an SKF is removed. Worst case scenario is the applicable SKF is at the end of an ETS table, but that lookup is only done one time per hash.

This means we can keep SKF unique by session_key, and delete in constant time.

### Other things of note
- We no longer assume that if 2 routes have a valid SKF, the latest one wins. Now, both routes will be routed to.
- There's a cleanup job for phash routing. I based it loosely off of packet-purchaser unique packet hash counter. 
  - It crawls the table more often than the removal window to keep the table from getting bigger than can be traversed in a single window.
  - packet-purchaser was doing this while being a default router.
- There as a multi-buy test that was relying on a race condition. 
  - There was a max_copies of 3, and we were simulating 2 servers for every request. The test asserted that 3 requests were sent, but that could only happen if request 2 and 3 were sent at the same time. 
  - It's been updated to wait until multi-buy has received more than max_copies worth of function calls, and makes sure it's sent less than the expected requests.