### PR TITLE
rehydrate since

### DIFF
--- a/config/ct.config
+++ b/config/ct.config
@@ -24,7 +24,8 @@
         }},
         {multi_buy_enabled, true},
         {routing_cache_window_secs, 5},
-        {routing_cache_timeout_secs, 10}
+        {routing_cache_timeout_secs, 10},
+        {ics_stream_worker_checkpoint_secs, 3}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env]},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -25,7 +25,8 @@
             port => "${HPR_MULTI_BUY_SERVICE_PORT}"
         }},
         {routing_cache_timeout_secs, 15},
-        {routing_cache_window_secs, 120}
+        {routing_cache_window_secs, 120},
+        {ics_stream_worker_checkpoint_secs, 300}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env, aws_credentials_ec2]}

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
     {hackney, "1.17.0"},
     {aws, {git, "https://github.com/aws-beam/aws-erlang.git", {tag, "0.7.1"}}},
     {aws_credentials, {git, "https://github.com/aws-beam/aws_credentials.git", {tag, "0.1.9"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "bbalser/iot-config-since"}}},
     {erlang_lorawan, {git, "https://github.com/helium/erlang-lorawan.git", {branch, "master"}}},
     {libp2p_crypto, {git, "https://github.com/helium/libp2p_crypto.git", {tag, "v1.5.2"}}},
     {iso8601, ".*", {git, "https://github.com/erlsci/iso8601.git", {tag, "1.3.1"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
     {hackney, "1.17.0"},
     {aws, {git, "https://github.com/aws-beam/aws-erlang.git", {tag, "0.7.1"}}},
     {aws_credentials, {git, "https://github.com/aws-beam/aws_credentials.git", {tag, "0.1.9"}}},
-    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "bbalser/iot-config-since"}}},
+    {helium_proto, {git, "https://github.com/helium/proto.git", {branch, "master"}}},
     {erlang_lorawan, {git, "https://github.com/helium/erlang-lorawan.git", {branch, "master"}}},
     {libp2p_crypto, {git, "https://github.com/helium/libp2p_crypto.git", {tag, "v1.5.2"}}},
     {iso8601, ".*", {git, "https://github.com/erlsci/iso8601.git", {tag, "1.3.1"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -63,7 +63,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.17.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"8d81732f55aa34442ada818c93f504f1a16ca659"}},
+       {ref,"5a4f167360fd23bedb41faba53d0cbe74da35052"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.3.0">>},2},
  {<<"http2_client">>,

--- a/rebar.lock
+++ b/rebar.lock
@@ -63,7 +63,7 @@
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.17.0">>},0},
  {<<"helium_proto">>,
   {git,"https://github.com/helium/proto.git",
-       {ref,"5a4f167360fd23bedb41faba53d0cbe74da35052"}},
+       {ref,"585704c871d32846a6e35d186a08443883545687"}},
   0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.3.0">>},2},
  {<<"http2_client">>,

--- a/src/grpc/iot_config/hpr_devaddr_range_storage.erl
+++ b/src/grpc/iot_config/hpr_devaddr_range_storage.erl
@@ -21,12 +21,12 @@
 -export([test_delete_ets/0, test_size/0, test_tab_name/0]).
 -endif.
 
--define(ETS_DEVADDR_RANGES, hpr_route_devaddr_ranges_ets).
--define(DETS_DEVADDR_RANGES, hpr_route_devaddr_ranges_dets).
+-define(ETS, hpr_route_devaddr_ranges_ets).
+-define(DETS, hpr_route_devaddr_ranges_dets).
 
 -spec init_ets() -> ok.
 init_ets() ->
-    ?ETS_DEVADDR_RANGES = ets:new(?ETS_DEVADDR_RANGES, [
+    ?ETS = ets:new(?ETS, [
         public, named_table, bag, {read_concurrency, true}
     ]),
     ok = rehydrate_from_dets(),
@@ -35,7 +35,7 @@ init_ets() ->
 -spec checkpoint() -> ok.
 checkpoint() ->
     with_open_dets(fun() ->
-        ok = dets:from_ets(?DETS_DEVADDR_RANGES, ?ETS_DEVADDR_RANGES)
+        ok = dets:from_ets(?DETS, ?ETS)
     end).
 
 -spec lookup(DevAddr :: non_neg_integer()) -> [hpr_route_ets:route()].
@@ -49,7 +49,7 @@ lookup(DevAddr) ->
             ['$3']
         }
     ],
-    RouteIDs = ets:select(?ETS_DEVADDR_RANGES, MS),
+    RouteIDs = ets:select(?ETS, MS),
 
     lists:usort(
         lists:flatten([
@@ -61,7 +61,7 @@ lookup(DevAddr) ->
 
 -spec insert(DevAddrRange :: hpr_devaddr_range:devaddr_range()) -> ok.
 insert(DevAddrRange) ->
-    true = ets:insert(?ETS_DEVADDR_RANGES, [
+    true = ets:insert(?ETS, [
         {
             {hpr_devaddr_range:start_addr(DevAddrRange), hpr_devaddr_range:end_addr(DevAddrRange)},
             hpr_devaddr_range:route_id(DevAddrRange)
@@ -79,7 +79,7 @@ insert(DevAddrRange) ->
 
 -spec delete(DevAddrRange :: hpr_devaddr_range:devaddr_range()) -> ok.
 delete(DevAddrRange) ->
-    true = ets:delete_object(?ETS_DEVADDR_RANGES, {
+    true = ets:delete_object(?ETS, {
         {hpr_devaddr_range:start_addr(DevAddrRange), hpr_devaddr_range:end_addr(DevAddrRange)},
         hpr_devaddr_range:route_id(DevAddrRange)
     }),
@@ -95,23 +95,23 @@ delete(DevAddrRange) ->
 
 -spec delete_all() -> ok.
 delete_all() ->
-    ets:delete_all_objects(?ETS_DEVADDR_RANGES),
+    ets:delete_all_objects(?ETS),
     ok.
 
 -ifdef(TEST).
 
 -spec test_delete_ets() -> ok.
 test_delete_ets() ->
-    ets:delete(?ETS_DEVADDR_RANGES),
+    ets:delete(?ETS),
     ok.
 
 -spec test_size() -> non_neg_integer().
 test_size() ->
-    ets:info(?ETS_DEVADDR_RANGES, size).
+    ets:info(?ETS, size).
 
 -spec test_tab_name() -> atom().
 test_tab_name() ->
-    ?ETS_DEVADDR_RANGES.
+    ?ETS.
 
 -endif.
 
@@ -123,12 +123,12 @@ test_tab_name() ->
     list({non_neg_integer(), non_neg_integer()}).
 lookup_for_route(RouteID) ->
     MS = [{{{'$1', '$2'}, RouteID}, [], [{{'$1', '$2'}}]}],
-    ets:select(?ETS_DEVADDR_RANGES, MS).
+    ets:select(?ETS, MS).
 
 -spec count_for_route(RouteID :: hpr_route:id()) -> non_neg_integer().
 count_for_route(RouteID) ->
     MS = [{{'_', RouteID}, [], [true]}],
-    ets:select_count(?ETS_DEVADDR_RANGES, MS).
+    ets:select_count(?ETS, MS).
 
 %% -------------------------------------------------------------------
 %% Route Stream Helpers
@@ -137,7 +137,7 @@ count_for_route(RouteID) ->
 -spec delete_route(hpr_route:id()) -> non_neg_integer().
 delete_route(RouteID) ->
     MS1 = [{{'_', RouteID}, [], [true]}],
-    ets:select_delete(?ETS_DEVADDR_RANGES, MS1).
+    ets:select_delete(?ETS, MS1).
 
 -spec replace_route(
     RouteID :: hpr_route:id(),
@@ -151,7 +151,7 @@ replace_route(RouteID, DevAddrRanges) ->
 -spec rehydrate_from_dets() -> ok.
 rehydrate_from_dets() ->
     with_open_dets(fun() ->
-        case dets:to_ets(?DETS_DEVADDR_RANGES, ?ETS_DEVADDR_RANGES) of
+        case dets:to_ets(?DETS, ?ETS) of
             {error, _Reason} ->
                 lager:error("failed ot hydrate ets: ~p", [_Reason]);
             _ ->
@@ -165,14 +165,10 @@ with_open_dets(FN) ->
     DETSFile = filename:join([DataDir, "hpr_devaddr_range_storage.dets"]),
     ok = filelib:ensure_dir(DETSFile),
 
-    case
-        dets:open_file(?DETS_DEVADDR_RANGES, [
-            {file, DETSFile}, {type, bag}, {keypos, hpr_route_ets:ets_keypos()}
-        ])
-    of
+    case dets:open_file(?DETS, [{file, DETSFile}, {type, bag}]) of
         {ok, _Dets} ->
             FN(),
-            dets:close(?DETS_DEVADDR_RANGES);
+            dets:close(?DETS);
         {error, Reason} ->
             Deleted = file:delete(DETSFile),
             lager:warning("failed to open dets file ~p: ~p, deleted: ~p", [?MODULE, Reason, Deleted]),

--- a/src/grpc/iot_config/hpr_eui_pair_storage.erl
+++ b/src/grpc/iot_config/hpr_eui_pair_storage.erl
@@ -178,11 +178,7 @@ with_open_dets(FN) ->
     DETSFile = filename:join([DataDir, "hpr_eui_pair_storage.dets"]),
     ok = filelib:ensure_dir(DETSFile),
 
-    case
-        dets:open_file(?DETS, [
-            {file, DETSFile}, {type, bag}, {keypos, hpr_route_ets:ets_keypos()}
-        ])
-    of
+    case dets:open_file(?DETS, [{file, DETSFile}, {type, set}]) of
         {ok, _Dets} ->
             lager:info("~s opened by ~p", [DETSFile, self()]),
             FN(),

--- a/src/grpc/iot_config/hpr_eui_pair_storage.erl
+++ b/src/grpc/iot_config/hpr_eui_pair_storage.erl
@@ -2,6 +2,7 @@
 
 -export([
     init_ets/0,
+checkpoint/0,
 
     insert/1,
     lookup/2,
@@ -22,24 +23,39 @@
 -export([test_delete_ets/0, test_size/0, test_tab_name/0]).
 -endif.
 
--define(ETS_EUI_PAIRS, hpr_route_eui_pairs_ets).
+-define(ETS, hpr_route_eui_pairs_ets).
+-define(DETS, hpr_route_eui_pairs_dets).
 
 -spec init_ets() -> ok.
 init_ets() ->
-    ?ETS_EUI_PAIRS = ets:new(?ETS_EUI_PAIRS, [public, named_table, bag, {read_concurrency, true}]),
+    ?ETS = ets:new(?ETS, [
+        public,
+        named_table,
+        bag,
+        {read_concurrency, true}
+    ]),
+    ok = rehydrate_from_dets(),
+
+    ok.
+
+-spec checkpoint() -> ok.
+checkpoint() ->
+    ok = open_dets(),
+    ok = dets:from_ets(?DETS, ?ETS),
+    ok = dets:close(?DETS),
     ok.
 
 -spec lookup(AppEUI :: non_neg_integer(), DevEUI :: non_neg_integer()) ->
     [hpr_route_ets:route()].
 lookup(AppEUI, 0) ->
-    EUIPairs = ets:lookup(?ETS_EUI_PAIRS, {AppEUI, 0}),
+    EUIPairs = ets:lookup(?ETS, {AppEUI, 0}),
     lists:flatten([
         Route
      || {_, RouteID} <- EUIPairs,
         {ok, Route} <- [hpr_route_storage:lookup(RouteID)]
     ]);
 lookup(AppEUI, DevEUI) ->
-    EUIPairs = ets:lookup(?ETS_EUI_PAIRS, {AppEUI, DevEUI}),
+    EUIPairs = ets:lookup(?ETS, {AppEUI, DevEUI}),
     lists:usort(
         lists:flatten([
             Route
@@ -50,7 +66,7 @@ lookup(AppEUI, DevEUI) ->
 
 -spec insert(EUIPair :: hpr_eui_pair:eui_pair()) -> ok.
 insert(EUIPair) ->
-    true = ets:insert(?ETS_EUI_PAIRS, [
+    true = ets:insert(?ETS, [
         {
             {hpr_eui_pair:app_eui(EUIPair), hpr_eui_pair:dev_eui(EUIPair)},
             hpr_eui_pair:route_id(EUIPair)
@@ -68,7 +84,7 @@ insert(EUIPair) ->
 
 -spec delete(EUIPair :: hpr_eui_pair:eui_pair()) -> ok.
 delete(EUIPair) ->
-    true = ets:delete_object(?ETS_EUI_PAIRS, {
+    true = ets:delete_object(?ETS, {
         {hpr_eui_pair:app_eui(EUIPair), hpr_eui_pair:dev_eui(EUIPair)},
         hpr_eui_pair:route_id(EUIPair)
     }),
@@ -84,23 +100,23 @@ delete(EUIPair) ->
 
 -spec delete_all() -> ok.
 delete_all() ->
-    ets:delete_all_objects(?ETS_EUI_PAIRS),
+    ets:delete_all_objects(?ETS),
     ok.
 
 -ifdef(TEST).
 
 -spec test_delete_ets() -> ok.
 test_delete_ets() ->
-    ets:delete(?ETS_EUI_PAIRS),
+    ets:delete(?ETS),
     ok.
 
 -spec test_size() -> non_neg_integer().
 test_size() ->
-    ets:info(?ETS_EUI_PAIRS, size).
+    ets:info(?ETS, size).
 
 -spec test_tab_name() -> atom().
 test_tab_name() ->
-    ?ETS_EUI_PAIRS.
+    ?ETS.
 
 -endif.
 
@@ -112,24 +128,24 @@ test_tab_name() ->
     list({AppEUI :: non_neg_integer(), DevEUI :: non_neg_integer()}).
 lookup_dev_eui(DevEUI) ->
     MS = [{{{'$1', DevEUI}, '_'}, [], [{{'$1', DevEUI}}]}],
-    ets:select(?ETS_EUI_PAIRS, MS).
+    ets:select(?ETS, MS).
 
 -spec lookup_app_eui(AppEUI :: non_neg_integer()) ->
     list({AppEUI :: non_neg_integer(), DevEUI :: non_neg_integer()}).
 lookup_app_eui(AppEUI) ->
     MS = [{{{AppEUI, '$1'}, '_'}, [], [{{AppEUI, '$1'}}]}],
-    ets:select(?ETS_EUI_PAIRS, MS).
+    ets:select(?ETS, MS).
 
 -spec lookup_for_route(RouteID :: hpr_route:id()) ->
     list({AppEUI :: non_neg_integer(), DevEUI :: non_neg_integer()}).
 lookup_for_route(RouteID) ->
     MS = [{{{'$1', '$2'}, RouteID}, [], [{{'$1', '$2'}}]}],
-    ets:select(?ETS_EUI_PAIRS, MS).
+    ets:select(?ETS, MS).
 
 -spec count_for_route(RouteID :: hpr_route:id()) -> non_neg_integer().
 count_for_route(RouteID) ->
     MS = [{{'_', RouteID}, [], [true]}],
-    ets:select_count(?ETS_EUI_PAIRS, MS).
+    ets:select_count(?ETS, MS).
 
 %% -------------------------------------------------------------------
 %% Route Stream Helpers
@@ -138,7 +154,7 @@ count_for_route(RouteID) ->
 -spec delete_route(hpr_route:id()) -> non_neg_integer().
 delete_route(RouteID) ->
     MS2 = [{{'_', RouteID}, [], [true]}],
-    ets:select_delete(?ETS_EUI_PAIRS, MS2).
+    ets:select_delete(?ETS, MS2).
 
 -spec replace_route(RouteID :: hpr_route:id(), EUIs :: list(hpr_eui_pair:eui_pair())) ->
     non_neg_integer().
@@ -146,3 +162,33 @@ replace_route(RouteID, EUIs) ->
     Removed = ?MODULE:delete_route(RouteID),
     lists:foreach(fun ?MODULE:insert/1, EUIs),
     Removed.
+
+-spec rehydrate_from_dets() -> ok.
+rehydrate_from_dets() ->
+    ok = open_dets(),
+
+    case dets:to_ets(?DETS, ?ETS) of
+        {error, _Reason} ->
+            lager:error("failed ot hydrate ets: ~p", [_Reason]);
+        _ ->
+            lager:info("ets hydrated")
+    end.
+
+-spec open_dets() -> ok.
+open_dets() ->
+    DataDir = hpr_utils:base_data_dir(),
+    DETSFile = filename:join([DataDir, "hpr_eui_pair_storage.dets"]),
+    ok = filelib:ensure_dir(DETSFile),
+
+    case
+        dets:open_file(?DETS, [
+            {file, DETSFile}, {type, bag}, {keypos, hpr_route_ets:ets_keypos()}
+        ])
+    of
+        {ok, _Dets} ->
+            ok;
+        {error, Reason} ->
+            Deleted = file:delete(DETSFile),
+            lager:warning("failed to open dets file ~p: ~p, deleted: ~p", [?MODULE, Reason, Deleted]),
+            rehydrate_from_dets()
+    end.

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -33,6 +33,7 @@
 init() ->
     ok = hpr_route_storage:init_ets(),
     ok = hpr_devaddr_range_storage:init_ets(),
+    %% SKF hydration is handled by route hydration
     ok = hpr_eui_pair_storage:init_ets(),
     ok.
 

--- a/src/grpc/iot_config/hpr_route_storage.erl
+++ b/src/grpc/iot_config/hpr_route_storage.erl
@@ -20,39 +20,40 @@
 -export([test_delete_ets/0, test_size/0]).
 -endif.
 
--define(ETS_ROUTES, hpr_routes_ets).
+-define(ETS, hpr_routes_ets).
+-define(DETS, hpr_routes_dets).
 
 -spec init_ets() -> ok.
 init_ets() ->
-    ?ETS_ROUTES = ets:new(?ETS_ROUTES, [
+    ?ETS = ets:new(?ETS, [
         public,
         named_table,
         set,
         {keypos, hpr_route_ets:ets_keypos()},
         {read_concurrency, true}
     ]),
-    ok = open_dets(),
-    [] = dets:traverse(
-        ?MODULE,
-        fun(RouteETS) ->
-            Route = hpr_route_ets:route(RouteETS),
-            ok = ?MODULE:insert(Route),
-            continue
-        end
-    ),
+    with_open_dets(fun() ->
+        [] = dets:traverse(
+            ?DETS,
+            fun(RouteETS) ->
+                Route = hpr_route_ets:route(RouteETS),
+                ok = ?MODULE:insert(Route),
+                continue
+            end
+        )
+    end),
 
     ok.
 
 -spec checkpoint() -> ok.
 checkpoint() ->
-    ok = open_dets(),
-    ok = dets:from_ets(?MODULE, ?ETS_ROUTES),
-    ok = dets:close(?MODULE),
-    ok.
+    with_open_dets(fun() ->
+        ok = dets:from_ets(?DETS, ?ETS)
+    end).
 
 -spec lookup(ID :: hpr_route:id()) -> {ok, hpr_route_ets:route()} | {error, not_found}.
 lookup(ID) ->
-    case ets:lookup(?ETS_ROUTES, ID) of
+    case ets:lookup(?ETS, ID) of
         [Route] ->
             {ok, Route};
         _Other ->
@@ -82,7 +83,7 @@ insert(Route, SKFETS) ->
 ) -> ok.
 insert(Route, SKFETS, Backoff) ->
     RouteETS = hpr_route_ets:new(Route, SKFETS, Backoff),
-    true = ets:insert(?ETS_ROUTES, RouteETS),
+    true = ets:insert(?ETS, RouteETS),
     Server = hpr_route:server(Route),
     RouteFields = [
         {id, hpr_route:id(Route)},
@@ -106,7 +107,7 @@ delete(Route) ->
     EUIsEntries = hpr_eui_pair_storage:delete_route(RouteID),
     SKFEntries = hpr_skf_storage:delete_route(RouteID),
 
-    true = ets:delete(?ETS_ROUTES, RouteID),
+    true = ets:delete(?ETS, RouteID),
     lager:info(
         [{devaddr, DevAddrEntries}, {euis, EUIsEntries}, {skfs, SKFEntries}, {route_id, RouteID}],
         "route deleted"
@@ -115,24 +116,24 @@ delete(Route) ->
 
 -spec delete_all() -> ok.
 delete_all() ->
-    ets:delete_all_objects(?ETS_ROUTES),
+    ets:delete_all_objects(?ETS),
     ok.
 
 -spec set_backoff(RouteID :: hpr_route:id(), Backoff :: hpr_route_ets:backoff()) -> ok.
 set_backoff(RouteID, Backoff) ->
-    true = ets:update_element(?ETS_ROUTES, RouteID, {5, Backoff}),
+    true = ets:update_element(?ETS, RouteID, {5, Backoff}),
     ok.
 
 -ifdef(TEST).
 
 -spec test_delete_ets() -> ok.
 test_delete_ets() ->
-    ets:delete(?ETS_ROUTES),
+    ets:delete(?ETS),
     ok.
 
 -spec test_size() -> non_neg_integer().
 test_size() ->
-    ets:info(?ETS_ROUTES, size).
+    ets:info(?ETS, size).
 
 -endif.
 
@@ -142,17 +143,17 @@ test_size() ->
 
 -spec all_routes() -> list(hpr_route:route()).
 all_routes() ->
-    [hpr_route_ets:route(R) || R <- ets:tab2list(?ETS_ROUTES)].
+    [hpr_route_ets:route(R) || R <- ets:tab2list(?ETS)].
 
 -spec all_route_ets() -> list(hpr_route_ets:route()).
 all_route_ets() ->
-    ets:tab2list(?ETS_ROUTES).
+    ets:tab2list(?ETS).
 
 -spec oui_routes(OUI :: non_neg_integer()) -> list(hpr_route_ets:route()).
 oui_routes(OUI) ->
     [
         RouteETS
-     || RouteETS <- ets:tab2list(?ETS_ROUTES), OUI == hpr_route:oui(hpr_route_ets:route(RouteETS))
+     || RouteETS <- ets:tab2list(?ETS), OUI == hpr_route:oui(hpr_route_ets:route(RouteETS))
     ].
 
 %% ------------------------------------------------------------------
@@ -178,21 +179,23 @@ oui_routes(OUI) ->
 %% Internal Functions
 %% -------------------------------------------------------------------
 
--spec open_dets() -> ok.
-open_dets() ->
+with_open_dets(FN) ->
     DataDir = hpr_utils:base_data_dir(),
     DETSFile = filename:join([DataDir, "hpr_routes_storage.dets"]),
     ok = filelib:ensure_dir(DETSFile),
 
     case
-        dets:open_file(?MODULE, [
-            {file, DETSFile}, {type, set}, {keypos, hpr_route_ets:ets_keypos()}
+        dets:open_file(?DETS, [
+            {file, DETSFile}, {type, bag}, {keypos, hpr_route_ets:ets_keypos()}
         ])
     of
         {ok, _Dets} ->
-            ok;
+            lager:info("~s opened by ~p", [DETSFile, self()]),
+            FN(),
+            dets:close(?DETS);
+        %% ok;
         {error, Reason} ->
             Deleted = file:delete(DETSFile),
             lager:warning("failed to open dets file ~p: ~p, deleted: ~p", [?MODULE, Reason, Deleted]),
-            open_dets()
+            with_open_dets(FN)
     end.

--- a/src/grpc/iot_config/hpr_route_storage.erl
+++ b/src/grpc/iot_config/hpr_route_storage.erl
@@ -137,6 +137,25 @@ oui_routes(OUI) ->
      || RouteETS <- ets:tab2list(?ETS_ROUTES), OUI == hpr_route:oui(hpr_route_ets:route(RouteETS))
     ].
 
+%% ------------------------------------------------------------------
+%% CLI Functions
+%% ------------------------------------------------------------------
+
+-spec all_routes() -> list(hpr_route:route()).
+all_routes() ->
+    [hpr_route_ets:route(R) || R <- ets:tab2list(?ETS_ROUTES)].
+
+-spec all_route_ets() -> list(route()).
+all_route_ets() ->
+    ets:tab2list(?ETS_ROUTES).
+
+-spec oui_routes(OUI :: non_neg_integer()) -> list(route()).
+oui_routes(OUI) ->
+    [
+        RouteETS
+     || RouteETS <- ets:tab2list(?ETS_ROUTES), OUI == hpr_route:oui(hpr_route_ets:route(RouteETS))
+    ].
+
 %% -------------------------------------------------------------------
 %% Internal Functions
 %% -------------------------------------------------------------------

--- a/src/grpc/iot_config/hpr_route_storage.erl
+++ b/src/grpc/iot_config/hpr_route_storage.erl
@@ -186,7 +186,7 @@ with_open_dets(FN) ->
 
     case
         dets:open_file(?DETS, [
-            {file, DETSFile}, {type, bag}, {keypos, hpr_route_ets:ets_keypos()}
+            {file, DETSFile}, {type, set}, {keypos, hpr_route_ets:ets_keypos()}
         ])
     of
         {ok, _Dets} ->

--- a/src/grpc/iot_config/hpr_route_storage.erl
+++ b/src/grpc/iot_config/hpr_route_storage.erl
@@ -156,25 +156,6 @@ oui_routes(OUI) ->
      || RouteETS <- ets:tab2list(?ETS), OUI == hpr_route:oui(hpr_route_ets:route(RouteETS))
     ].
 
-%% ------------------------------------------------------------------
-%% CLI Functions
-%% ------------------------------------------------------------------
-
--spec all_routes() -> list(hpr_route:route()).
-all_routes() ->
-    [hpr_route_ets:route(R) || R <- ets:tab2list(?ETS_ROUTES)].
-
--spec all_route_ets() -> list(route()).
-all_route_ets() ->
-    ets:tab2list(?ETS_ROUTES).
-
--spec oui_routes(OUI :: non_neg_integer()) -> list(route()).
-oui_routes(OUI) ->
-    [
-        RouteETS
-     || RouteETS <- ets:tab2list(?ETS_ROUTES), OUI == hpr_route:oui(hpr_route_ets:route(RouteETS))
-    ].
-
 %% -------------------------------------------------------------------
 %% Internal Functions
 %% -------------------------------------------------------------------

--- a/src/grpc/iot_config/hpr_route_stream_req.erl
+++ b/src/grpc/iot_config/hpr_route_stream_req.erl
@@ -3,11 +3,12 @@
 -include("../autogen/iot_config_pb.hrl").
 
 -export([
-    new/1,
+    new/1, new/2,
     timestamp/1,
     signer/1,
     signature/1,
     sign/2,
+    since/1,
     verify/1
 ]).
 
@@ -17,9 +18,14 @@
 
 -spec new(Signer :: libp2p_crypto:pubkey_bin()) -> req().
 new(Signer) ->
+    new(Signer, 0).
+
+-spec new(Signer :: libp2p_crypto:pubkey_bin(), Since :: non_neg_integer()) -> req().
+new(Signer, Since) ->
     #iot_config_route_stream_req_v1_pb{
         signer = Signer,
-        timestamp = erlang:system_time(millisecond)
+        timestamp = erlang:system_time(millisecond),
+        since = Since
     }.
 
 -spec timestamp(RouteStreamReq :: req()) -> non_neg_integer().
@@ -40,6 +46,10 @@ sign(RouteStreamReq, SigFun) ->
         RouteStreamReq, iot_config_route_stream_req_v1_pb
     ),
     RouteStreamReq#iot_config_route_stream_req_v1_pb{signature = SigFun(EncodedRouteStreamReq)}.
+
+-spec since(RouteStreamReq :: req()) -> non_neg_integer().
+since(RouteStreamReq) ->
+    RouteStreamReq#iot_config_route_stream_req_v1_pb.since.
 
 -spec verify(RouteStreamReq :: req()) -> boolean().
 verify(RouteStreamReq) ->

--- a/src/grpc/iot_config/hpr_route_stream_res.erl
+++ b/src/grpc/iot_config/hpr_route_stream_res.erl
@@ -4,7 +4,8 @@
 
 -export([
     action/1,
-    data/1
+    data/1,
+    timestamp/1
 ]).
 
 -ifdef(TEST).
@@ -30,6 +31,10 @@ action(RouteStreamRes) ->
 data(RouteStreamRes) ->
     RouteStreamRes#iot_config_route_stream_res_v1_pb.data.
 
+-spec timestamp(RouteStreamRes :: res()) -> non_neg_integer().
+timestamp(RouteStreamRes) ->
+    RouteStreamRes#iot_config_route_stream_res_v1_pb.timestamp.
+
 %% ------------------------------------------------------------------
 %% Tests Functions
 %% ------------------------------------------------------------------
@@ -39,7 +44,8 @@ data(RouteStreamRes) ->
 test_new(Map) ->
     #iot_config_route_stream_res_v1_pb{
         action = maps:get(action, Map),
-        data = maps:get(data, Map)
+        data = maps:get(data, Map),
+        timestamp = maps:get(timestamp, Map, 0)
     }.
 
 -endif.

--- a/src/grpc/iot_config/hpr_route_stream_res.erl
+++ b/src/grpc/iot_config/hpr_route_stream_res.erl
@@ -33,7 +33,14 @@ data(RouteStreamRes) ->
 
 -spec timestamp(RouteStreamRes :: res()) -> non_neg_integer().
 timestamp(RouteStreamRes) ->
-    RouteStreamRes#iot_config_route_stream_res_v1_pb.timestamp.
+    %% NOTE: All requests are sent with a millisecond timestamp.
+    %% Responses have Second timestamps.
+    %% HPR speaks exclusively in millisecond.
+    erlang:convert_time_unit(
+        RouteStreamRes#iot_config_route_stream_res_v1_pb.timestamp,
+        second,
+        millisecond
+    ).
 
 %% ------------------------------------------------------------------
 %% Tests Functions

--- a/src/grpc/iot_config/hpr_route_stream_worker.erl
+++ b/src/grpc/iot_config/hpr_route_stream_worker.erl
@@ -283,9 +283,7 @@ handle_info({data, _StreamID, RouteStreamRes}, #state{counts = Counts0} = State)
     Counts1 = Counts0#{Type => maps:get(Type, Counts0, 0) + 1},
     _ = erlang:spawn(
         fun() ->
-            lager:debug([{action, Action}, {type, Type}], "processing update"),
             ok = process_route_stream_res(Action, Data),
-            lager:debug([{action, Action}, {type, Type}], "done processing"),
             ok = hpr_metrics:ics_update(Type, Action)
         end
     ),

--- a/src/grpc/iot_config/hpr_route_stream_worker.erl
+++ b/src/grpc/iot_config/hpr_route_stream_worker.erl
@@ -177,18 +177,22 @@ reset_timestamp() ->
 checkpoint_timer() ->
     gen_server:call(?MODULE, checkpoint_timer).
 
--spec print_next_checkpoint() -> ok.
+-spec print_next_checkpoint() -> string().
 print_next_checkpoint() ->
-    case ?MODULE:checkpoint_timer() of
-        undefined ->
-            lager:info("Timer not active");
-        {TimeScheduled, _TimerRef} ->
-            Now = erlang:system_time(millisecond),
-            TimeLeft = Now - TimeScheduled,
-            TotalSeconds = erlang:convert_time_unit(TimeLeft, millisecond, second),
-            {_Hour, Minute, Seconds} = calendar:seconds_to_time(TotalSeconds),
-            lager:info("Running again in T- ~pm ~ps", [Minute, Seconds])
-    end.
+    Msg =
+        case ?MODULE:checkpoint_timer() of
+            undefined ->
+                "Timer not active";
+            {TimeScheduled, _TimerRef} ->
+                Now = erlang:system_time(millisecond),
+                TimeLeft = Now - TimeScheduled,
+                TotalSeconds = erlang:convert_time_unit(TimeLeft, millisecond, second),
+                {_Hour, Minute, Seconds} = calendar:seconds_to_time(TotalSeconds),
+                io_lib:format("Running again in T- ~pm ~ps", [Minute, Seconds])
+        end,
+    lager:info(Msg),
+    Msg.
+
 
 -ifdef(TEST).
 

--- a/src/grpc/iot_config/hpr_skf_storage.erl
+++ b/src/grpc/iot_config/hpr_skf_storage.erl
@@ -215,6 +215,18 @@ delete_route(RouteID) ->
             DetsFilename = ?MODULE:dets_filename(RouteID),
             _ = file:delete(DetsFilename),
             Size;
+        {error, not_found} = Err ->
+            DetsFilename = ?MODULE:dets_filename(RouteID),
+            Deleted = file:delete(DetsFilename),
+            lager:info(
+                [
+                    {route_id, RouteID},
+                    {deleted, Deleted},
+                    {filename, DetsFilename}
+                ],
+                "route not found, skf file maybe deleted"
+            ),
+            Err;
         Other ->
             lager:warning("failed to delete skf table ~p for ~s", [Other, RouteID]),
             {error, Other}

--- a/src/grpc/iot_config/hpr_skf_storage.erl
+++ b/src/grpc/iot_config/hpr_skf_storage.erl
@@ -42,10 +42,8 @@ make_ets(RouteID) ->
         {heir, erlang:whereis(?SKF_HEIR), RouteID}
     ]),
 
-    erlang:spawn(fun() ->
-        lager:info("rehydrating SKF from dets: ~p", [RouteID]),
-        ok = rehydrate_from_dets(RouteID, Ref)
-    end),
+    lager:info("rehydrating SKF from dets: ~p", [RouteID]),
+    ok = rehydrate_from_dets(RouteID, Ref),
 
     Ref.
 

--- a/src/hpr_utils.erl
+++ b/src/hpr_utils.erl
@@ -233,7 +233,6 @@ b58() ->
 -spec base_data_dir() -> string().
 base_data_dir() ->
     DataDir = application:get_env(?APP, data_dir, ?DATA_DIR),
-    lager:info("base data dir ~s", [DataDir]),
     ok = filelib:ensure_dir(DataDir),
     DataDir.
 

--- a/src/metrics/hpr_metrics.erl
+++ b/src/metrics/hpr_metrics.erl
@@ -151,7 +151,7 @@ counts() ->
     [
         {routes, ets:info(hpr_routes_ets, size)},
         {eui_pairs, ets:info(hpr_route_eui_pairs_ets, size)},
-        {devaddr_ranges, ets:info(hpr_route_devaddr_range_ets, size)},
+        {devaddr_ranges, ets:info(hpr_route_devaddr_ranges_ets, size)},
         {skfs,
             lists:foldl(
                 fun(RouteETS, Acc) ->

--- a/src/metrics/hpr_metrics.erl
+++ b/src/metrics/hpr_metrics.erl
@@ -20,6 +20,10 @@
     observe_gateway_location/2
 ]).
 
+-export([
+    counts/0
+]).
+
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
 %% ------------------------------------------------------------------
@@ -139,6 +143,29 @@ observe_gateway_location(Start, Status) ->
     ).
 
 %% ------------------------------------------------------------------
+%% CLI Function Definitions
+%% ------------------------------------------------------------------
+
+-spec counts() -> proplists:proplist().
+counts() ->
+    [
+        {routes, ets:info(hpr_routes_ets, size)},
+        {eui_pairs, ets:info(hpr_route_eui_pairs_ets, size)},
+        {devaddr_ranges, ets:info(hpr_route_devaddr_range_ets, size)},
+        {skfs,
+            lists:foldl(
+                fun(RouteETS, Acc) ->
+                    case ets:info(hpr_route_ets:skf_ets(RouteETS), size) of
+                        undefined -> Acc;
+                        N -> N + Acc
+                    end
+                end,
+                0,
+                ets:tab2list(hpr_routes_ets)
+            )}
+    ].
+
+%% ------------------------------------------------------------------
 %% gen_server Function Definitions
 %% ------------------------------------------------------------------
 init(_Args) ->
@@ -212,6 +239,7 @@ declare_metrics() ->
         end,
         ?METRICS
     ).
+
 
 -spec record_routes() -> ok.
 record_routes() ->

--- a/test/hpr_route_stream_worker_SUITE.erl
+++ b/test/hpr_route_stream_worker_SUITE.erl
@@ -130,7 +130,7 @@ app_restart_rehydrate_test(_Config) ->
         max_copies => 1
     }),
 
-    hpr_test_iot_config_service_route:stream_resp(
+    hpr_test_ics_route_service:stream_resp(
         hpr_route_stream_res:test_new(#{action => add, data => {route, Route1}, timestamp => 100})
     ),
     timer:sleep(100),
@@ -146,7 +146,7 @@ app_restart_rehydrate_test(_Config) ->
             action => add, data => {skf, SessionKeyFilter1}, timestamp => 100
         })
     ],
-    [ok = hpr_test_iot_config_service_route:stream_resp(Update) || Update <- Updates1],
+    [ok = hpr_test_ics_route_service:stream_resp(Update) || Update <- Updates1],
     ct:print("all updates sent"),
     timer:sleep(timer:seconds(1)),
 
@@ -164,7 +164,7 @@ app_restart_rehydrate_test(_Config) ->
     ),
 
     %% Timestamps are inclusive, send a route update to bump the last timestamp
-    hpr_test_iot_config_service_route:stream_resp(
+    hpr_test_ics_route_service:stream_resp(
         hpr_route_stream_res:test_new(#{action => add, data => {route, Route1}, timestamp => 150})
     ),
     ok = timer:sleep(150),
@@ -184,7 +184,7 @@ app_restart_rehydrate_test(_Config) ->
             Stream = hpr_route_stream_worker:test_stream(),
             %% {state, Stream, _Backoff} = sys:get_state(hpr_route_stream_worker),
             Stream =/= undefined andalso
-                erlang:is_pid(erlang:whereis(hpr_test_iot_config_service_route))
+                erlang:is_pid(erlang:whereis(hpr_test_ics_route_service))
         end,
         20,
         500
@@ -296,7 +296,7 @@ stream_crash_resume_updates_test(_Config) ->
             action => add, data => {skf, SessionKeyFilter1}, timestamp => 100
         })
     ],
-    [ok = hpr_test_iot_config_service_route:stream_resp(Update) || Update <- Updates1],
+    [ok = hpr_test_ics_route_service:stream_resp(Update) || Update <- Updates1],
 
     %% make sure all the data was received
     %% ok = timer:sleep(150),
@@ -312,7 +312,7 @@ stream_crash_resume_updates_test(_Config) ->
     ),
 
     %% Timestamps are inclusive, send a route update to bump the last timestamp
-    hpr_test_iot_config_service_route:stream_resp(
+    hpr_test_ics_route_service:stream_resp(
         hpr_route_stream_res:test_new(#{action => add, data => {route, Route1}, timestamp => 150})
     ),
     ok = timer:sleep(150),
@@ -325,7 +325,7 @@ stream_crash_resume_updates_test(_Config) ->
             whereis(hpr_route_stream_worker) =/= undefined andalso
                 erlang:is_process_alive(whereis(hpr_route_stream_worker)) andalso
                 hpr_route_stream_worker:test_stream() =/= undefined andalso
-                erlang:is_pid(erlang:whereis(hpr_test_iot_config_service_route))
+                erlang:is_pid(erlang:whereis(hpr_test_ics_route_service))
         end,
         20,
         500
@@ -376,7 +376,7 @@ stream_crash_resume_updates_test(_Config) ->
                     action => add, data => {skf, SessionKeyFilter2}, timestamp => 200
                 })
             ],
-    [ok = hpr_test_iot_config_service_route:stream_resp(Update) || Update <- Updates2],
+    [ok = hpr_test_ics_route_service:stream_resp(Update) || Update <- Updates2],
 
     %% make sure only the new data was received
     timer:sleep(timer:seconds(1)),

--- a/test/hpr_test_downlink_service_http_roaming.erl
+++ b/test/hpr_test_downlink_service_http_roaming.erl
@@ -24,6 +24,10 @@
 -spec init(atom(), StreamState :: grpcbox_stream:t()) -> grpcbox_stream:t().
 init(_RPC, StreamState) ->
     Self = self(),
+    case lists:member(?MODULE, erlang:registered()) of
+        false -> ok;
+        true -> erlang:unregister(?MODULE)
+    end,
     true = erlang:register(?MODULE, self()),
     PubKeyBin = hpr_utils:pubkey_bin(),
     lager:notice("init ~p @ ~p with signer ~p", [?MODULE, Self, PubKeyBin]),

--- a/test/test_utils.erl
+++ b/test/test_utils.erl
@@ -89,7 +89,8 @@ init_per_testcase(TestCase, Config) ->
 
     ok = test_utils:wait_until(
         fun() ->
-            {state, Stream, _Backoff} = sys:get_state(hpr_route_stream_worker),
+            Stream = hpr_route_stream_worker:test_stream(),
+            %% {state, Stream, _Backoff} = sys:get_state(hpr_route_stream_worker),
             Stream =/= undefined andalso
                 erlang:is_pid(erlang:whereis(hpr_test_ics_route_service))
         end,


### PR DESCRIPTION
- rehydrate config from dets files upon startup
- when starting the config update stream, send the timestamp of the last update we recieved

- todo: if any of the config cannot be rehydrated, remove everything and start from the beginning.