### PR TITLE
Add network field to metadata

### DIFF
--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -238,6 +238,7 @@ packet_up_to_push_data(Up, GatewayTime, GatewayLocation) ->
     Name = erlang:list_to_binary(hpr_utils:gateway_name(PubKeyBin)),
 
     BaseMeta = #{
+        network => <<"helium_iot">>,
         gateway_id => B58,
         gateway_name => Name,
         regi => hpr_packet_up:region(Up)

--- a/test/hpr_protocol_gwmp_SUITE.erl
+++ b/test/hpr_protocol_gwmp_SUITE.erl
@@ -783,6 +783,7 @@ verify_push_data(PacketUp, PushDataBinary) ->
                     <<"time">> => fun erlang:is_binary/1,
                     <<"tmst">> => hpr_packet_up:timestamp(PacketUp) band 16#FFFF_FFFF,
                     <<"meta">> => #{
+                        <<"network">> => <<"helium_iot">>,
                         <<"gateway_id">> => erlang:list_to_binary(
                             libp2p_crypto:bin_to_b58(PubKeyBin)
                         ),
@@ -826,6 +827,7 @@ verify_push_data_with_location(PacketUp, PushDataBinary, IndexString) ->
                     <<"time">> => fun erlang:is_binary/1,
                     <<"tmst">> => hpr_packet_up:timestamp(PacketUp) band 16#FFFF_FFFF,
                     <<"meta">> => #{
+                        <<"network">> => <<"helium_iot">>,
                         <<"gateway_id">> => erlang:list_to_binary(
                             libp2p_crypto:bin_to_b58(PubKeyBin)
                         ),


### PR DESCRIPTION
Ref https://github.com/helium/helium-packet-router/issues/285

In the metadata for a gateway/hotspot that is sent to ChirpStack, explicitly state that this packet comes from the Helium IoT network. This would help services on the other side of ChirpStack know for sure if the packet was received by Helium, without having to guess from the other metadata fields.