### PR TITLE
Fix various crashes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: tar
         run: tar -cvzf build.tar.gz -C _build/ .
       - name: upload-artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build.tar.gz
@@ -61,7 +61,7 @@ jobs:
         with:
           toolchain: stable
       - name: download-artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
       - name: untar
@@ -90,7 +90,7 @@ jobs:
         with:
           toolchain: stable
       - name: download-artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
       - name: untar
@@ -119,7 +119,7 @@ jobs:
         with:
           toolchain: stable
       - name: download-artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
       - name: untar
@@ -194,7 +194,7 @@ jobs:
         with:
           toolchain: stable
       - name: download-artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
       - name: untar
@@ -223,7 +223,7 @@ jobs:
         with:
           toolchain: stable
       - name: download-artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: build
       - name: untar

--- a/src/metrics/hpr_metrics.erl
+++ b/src/metrics/hpr_metrics.erl
@@ -381,10 +381,10 @@ get_pid_name(Pid) ->
 
 -spec name_to_pid(list()) -> pid() | undefined.
 name_to_pid(Name) ->
-    case erlang:length(string:split(Name, ".")) > 1 of
-        true ->
-            erlang:list_to_pid(Name);
-        false ->
+    try erlang:list_to_pid(Name) of
+        Pid -> Pid
+    catch
+        _ ->
             erlang:whereis(erlang:list_to_atom(Name))
     end.
 

--- a/src/metrics/hpr_metrics.erl
+++ b/src/metrics/hpr_metrics.erl
@@ -384,7 +384,7 @@ name_to_pid(Name) ->
     try erlang:list_to_pid(Name) of
         Pid -> Pid
     catch
-        _ ->
+        _E:_R ->
             erlang:whereis(erlang:list_to_atom(Name))
     end.
 

--- a/src/protocols/hpr_protocol_gwmp.erl
+++ b/src/protocols/hpr_protocol_gwmp.erl
@@ -9,9 +9,26 @@
     GatewayLocation :: hpr_gateway_location:loc()
 ) -> ok | {error, any()}.
 send(PacketUp, Route, Timestamp, GatewayLocation) ->
+    send(PacketUp, Route, Timestamp, GatewayLocation, 3).
+
+-spec send(
+    Packet :: hpr_packet_up:packet(),
+    Route :: hpr_route:route(),
+    Timestamp :: non_neg_integer(),
+    GatewayLocation :: hpr_gateway_location:loc(),
+    Retry :: non_neg_integer()
+) -> ok | {error, any()}.
+send(_PacketUp, _Route, _Timestamp, _GatewayLocation, 0) ->
+    {error, {gwmp_sup_err, max_retries}};
+send(PacketUp, Route, Timestamp, GatewayLocation, Retry) ->
     Gateway = hpr_packet_up:gateway(PacketUp),
     Key = {?MODULE, Gateway},
     case hpr_gwmp_sup:maybe_start_worker(#{key => Key, pubkeybin => Gateway}) of
+        % This should only happen when a hotspot connects and spams us with
+        % mutliple packet for same LNS
+        {error, already_registered} ->
+            timer:sleep(2),
+            send(PacketUp, Route, Timestamp, GatewayLocation, Retry - 1);
         {error, Reason} ->
             {error, {gwmp_sup_err, Reason}};
         {ok, Pid} ->

--- a/src/protocols/hpr_protocol_http_roaming.erl
+++ b/src/protocols/hpr_protocol_http_roaming.erl
@@ -30,11 +30,10 @@ send(PacketUp, Route, Timestamp, GatewayLocation) ->
     Retry :: non_neg_integer()
 ) -> ok | {error, any()}.
 send(_PacketUp, _Route, _Timestamp, _GatewayLocation, 0) ->
-    {error, {gwmp_sup_err, max_retries}};
+    {error, {roaming_sup_err, max_retries}};
 send(PacketUp, Route, Timestamp, GatewayLocation, Retry) ->
     Protocol = protocol_from(Route),
     WorkerKey = worker_key_from(PacketUp, Protocol),
-    PubKeyBin = hpr_packet_up:gateway(PacketUp),
     %% start worker
     case
         hpr_http_roaming_sup:maybe_start_worker(#{
@@ -44,12 +43,8 @@ send(PacketUp, Route, Timestamp, GatewayLocation, Retry) ->
         {error, already_registered} ->
             timer:sleep(2),
             send(PacketUp, Route, Timestamp, GatewayLocation, Retry - 1);
-        {error, Reason} = Err ->
-            lager:error(
-                "failed to start http connector for ~s: ~p",
-                [hpr_utils:gateway_name(PubKeyBin), Reason]
-            ),
-            Err;
+        {error, Reason} ->
+            {error, {roaming_sup_err, Reason}};
         {ok, WorkerPid} ->
             hpr_http_roaming_worker:handle_packet(WorkerPid, PacketUp, Timestamp, GatewayLocation),
             ok


### PR DESCRIPTION
### Issue

After a server “re-shuffle,” some Hotspot Packet Routers (HPRs) became unstable. When multiple hotspots reconnected to an HPR, the entire virtual machine (VM) could crash, even though the HPR had previously handled tens of thousands of connections without issue and had sufficient resources.

### Root Cause

The VM crash occurred due to multiple gwmp worker processes crashing on startup. These workers handle connections from the HPR to the LNS using the gwmp udp protocol (each hotspot is represented by one worker). The problem stemmed from a race condition in the registration process—when a hotspot reconnects with packets queued for immediate delivery, multiple workers would compete to establish the initial connection to the LNS and register themselves simultaneously. This caused subsequent workers to crash, leading to a cascading failure in the supervision tree, ultimately crashing the VM.

This issue was introduced in this [this commit](https://github.com/helium/helium-packet-router/commit/7aba67e949d50cb10ddebd1f162c1bbf9df890d0#diff-3da7320591447d82b358bb4854463ffcd1cc4d94933139145073c9254d9be5f2R93) while addressing a small memory leak.

### Fix

Implemented a mechanism to catch registration errors and retry up to 3 times when locating a worker, preventing race conditions during worker initialization.

### Additional Fixes

- Applied the same fix for HTTP roaming workers.
- Upgraded GitHub actions configuration.
- Fixed issues related to metrics:name_to_pid.

This update should improve the stability and resilience of HPRs during high-volume reconnection events.