### PR TITLE
Add slim runtime image and ECR push/delete workflows

### DIFF
--- a/.github/workflows/ECRDelete.yml
+++ b/.github/workflows/ECRDelete.yml
@@ -1,0 +1,49 @@
+name: ECRDelete
+run-name: Delete version ${{ inputs.version }} from ${{ inputs.environment }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: "Version to delete"
+        required: true
+      environment:
+        type: environment
+        description: "Target environment"
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  delete:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ inputs.version }}-${{ inputs.environment }}-delete
+      cancel-in-progress: true
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: gha_delete_${{ github.repository_id }}_${{ github.run_id }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Delete tag from ECR
+        run: |
+          set -euo pipefail
+          echo "Deleting tag '${{ inputs.version }}' from '${{ vars.ECR_REPOSITORY_NAME }}'"
+
+          FAILS=$(aws ecr batch-delete-image \
+            --repository-name "${{ vars.ECR_REPOSITORY_NAME }}" \
+            --image-ids imageTag="${{ inputs.version }}" \
+            --region "${{ vars.AWS_REGION }}" \
+            --query 'failures | length(@array)' \
+            --output text)
+
+          if [ "${FAILS}" != "0" ]; then
+            echo "ECR reported failures while deleting tag '${{ inputs.version }}'."
+            exit 1
+          fi

--- a/.github/workflows/ECRPush.yml
+++ b/.github/workflows/ECRPush.yml
@@ -1,0 +1,55 @@
+name: ECRPush
+run-name: Deploy version ${{ inputs.version }} to ${{ inputs.environment }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: "Version to deploy"
+        required: true
+      environment:
+        type: environment
+        description: "Target environment"
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  pull-push:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ inputs.version }}-${{ inputs.environment }}-pull-push
+      cancel-in-progress: true
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: gha_build_${{ github.repository_id }}_${{ github.run_id }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
+      - name: Pull from GHCR, tag for ECR, and push
+        run: |
+          SRC="ghcr.io/${{ github.repository }}:${{ inputs.version }}"
+          DST="${{ vars.ECR_URL }}:${{ inputs.version }}"
+
+          echo "Pulling $SRC"
+          docker pull "$SRC"
+
+          echo "Tagging $SRC -> $DST"
+          docker tag "$SRC" "$DST"
+
+          echo "Pushing $DST"
+          docker push "$DST"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,3 +311,33 @@ jobs:
         env:
           PACKAGECLOUD_API_KEY: ${{ secrets.PACKAGECLOUD_API_KEY }}
         run: ./.github/scripts/packagecloud_upload.sh
+
+  build-image:
+    needs: [xref, eunit, dialyzer, ct, ct-aws, release]
+    if: ${{ !failure() && !cancelled() && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-build-image
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+      - name: Build and Push App Image
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          file: Dockerfile
+          target: runner
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:24.3-alpine  AS base
+FROM erlang:24.3-alpine AS base
 
 RUN apk add --no-cache --update \
     autoconf automake bison build-base bzip2 cmake curl \
@@ -26,7 +26,7 @@ FROM base AS builder
 
 WORKDIR /opt/hpr
 
-# Build app depencies
+# Build app dependencies
 COPY Makefile Makefile
 COPY rebar3 rebar3
 COPY rebar.config rebar.config
@@ -44,8 +44,18 @@ RUN make compile
 # Build release
 RUN make release
 
-# Add tests
-COPY test/ test/
-RUN ./rebar3 compile as test
+# Slim runtime stage: same alpine/musl as builder so the
+# release-bundled erts and NIFs are ABI-compatible. Drops the build
+# toolchain (cmake, gcc, rust, etc.) and the source tree.
+FROM erlang:24.3-alpine AS runner
 
-CMD ["make", "run"]
+RUN apk add --no-cache \
+    libsodium \
+    libstdc++ \
+    ca-certificates
+
+WORKDIR /opt/hpr
+
+COPY --from=builder /opt/hpr/_build/default/rel/hpr ./rel
+
+CMD ["/opt/hpr/rel/bin/hpr", "foreground"]


### PR DESCRIPTION
## Summary

Refactors the Dockerfile to add a slim `runner` stage, adds a CI job to publish the runtime image to GHCR on tagged commits, and adds manual `ECRPush` / `ECRDelete` workflows for promoting a version into a target AWS environment — mirroring the pipeline in [helium/oracles](https://github.com/helium/oracles).

## What changed

- **Dockerfile**: new `runner` stage on `erlang:24.3-alpine` that copies only `_build/default/rel/hpr/` plus runtime libs (`libsodium`, `libstdc++`, `ca-certificates`). Drops the build toolchain (cmake, gcc, rust, autoconf, etc.) and the source tree. Same alpine/musl base as the builder so the embedded erts and Rust/C NIFs stay ABI-compatible. `CMD` invokes the release launcher directly (`/opt/hpr/rel/bin/hpr foreground`) so signals reach the Erlang VM as PID 1 instead of going through `make`. Also drops the `COPY test/` + `rebar3 compile as test` step from the builder — tests already run in CI via the base image, not this Dockerfile.
- **`.github/workflows/ci.yml`**: new `build-image` job, gated on the existing test/release jobs and `startsWith(github.ref, 'refs/tags/')`. Builds `target: runner` and pushes `ghcr.io/helium/helium-packet-router:<tag>`.
- **`.github/workflows/ECRPush.yml`** (new): manual `workflow_dispatch` with `version` + `environment` inputs. Pulls the GHCR image, retags for the target ECR, pushes. Uses AWS OIDC via `AWS_ROLE_ARN` / `AWS_REGION` and a single `ECR_URL` repo var (single-package repo, no matrix).
- **`.github/workflows/ECRDelete.yml`** (new): manual `workflow_dispatch` that deletes a tag from ECR via `aws ecr batch-delete-image`. Uses `ECR_REPOSITORY_NAME` for the repo name.

## Image size

Builder stage (what was previously deployable): ~2 GB.
Runner stage (what we'll push now): **~225 MB**.

## Config at runtime

No change to how config is provided. The release bundles `sys.config.src` with `${HPR_*}` env-var placeholders; the relx launcher substitutes them automatically at boot (verified by inspecting the launcher script and booting the image with a dummy env). Set the variables on the container as today (docker-compose `env_file`, ECS `environment`, k8s `env` / `envFrom`).

## Required repo / environment vars (configure before running ECR workflows)

- `AWS_ROLE_ARN`, `AWS_REGION` (per environment)
- `ECR_URL` — full image URI, e.g. `<acct>.dkr.ecr.<region>.amazonaws.com/helium-packet-router` (per environment, used by push)
- `ECR_REPOSITORY_NAME` — short name, e.g. `helium-packet-router` (per environment, used by delete)
- A matching GitHub Environment for each value of the `environment` input
