### PR TITLE
Fix dangling SKF table references that crash route operations

### DIFF
--- a/src/cli/hpr_cli_config.erl
+++ b/src/cli/hpr_cli_config.erl
@@ -835,8 +835,11 @@ set_routes_active(RoutesETS, Active) ->
             case Active of
                 false ->
                     %% When deactivating, remove all SKFs, DevAddr ranges, and EUIs
-                    %% but keep the route itself
-                    _ = hpr_skf_storage:delete_route(RouteID),
+                    %% but keep the route itself. Clear the SKF table in place
+                    %% rather than deleting it: the route record is kept, so
+                    %% destroying its skf_ets table would leave a dangling
+                    %% reference that crashes later route operations.
+                    _ = hpr_skf_storage:clear_route(RouteID),
                     _ = hpr_devaddr_range_storage:delete_route(RouteID),
                     _ = hpr_eui_pair_storage:delete_route(RouteID),
                     ok;

--- a/src/grpc/iot_config/hpr_route_ets.erl
+++ b/src/grpc/iot_config/hpr_route_ets.erl
@@ -114,6 +114,8 @@ all_test_() ->
         {"test_eui_pair", ?_test(test_eui_pair())},
         {"test_devaddr_range", ?_test(test_devaddr_range())},
         {"test_skf", ?_test(test_skf())},
+        {"test_replace_route_keeps_table", ?_test(test_replace_route_keeps_table())},
+        {"test_skf_tolerates_dead_table", ?_test(test_skf_tolerates_dead_table())},
         {"test_select_skf", ?_test(test_select_skf())},
         {"test_delete_route", ?_test(test_delete_route())},
         {"test_delete_all", ?_test(test_delete_all())}
@@ -421,6 +423,99 @@ test_skf() ->
     ?assertEqual(ok, hpr_skf_storage:delete(SKF2)),
     ?assertEqual([], hpr_skf_storage:lookup(SKFETS2, DevAddr2)),
 
+    ok.
+
+test_replace_route_keeps_table() ->
+    Route = hpr_route:test_new(#{
+        id => "11ea6dfd-3dce-4106-8980-d34007ab689b",
+        net_id => 0,
+        oui => 1,
+        server => #{
+            host => "lns1.testdomain.com",
+            port => 80,
+            protocol => {http_roaming, #{}}
+        },
+        max_copies => 1
+    }),
+    RouteID = hpr_route:id(Route),
+    ?assertEqual(ok, hpr_route_storage:insert(Route)),
+
+    DevAddr = 16#00000001,
+    SessionKey1 = hpr_utils:bin_to_hex_string(crypto:strong_rand_bytes(16)),
+    SessionKey2 = hpr_utils:bin_to_hex_string(crypto:strong_rand_bytes(16)),
+    SKF1 = hpr_skf:new(#{
+        route_id => RouteID, devaddr => DevAddr, session_key => SessionKey1, max_copies => 1
+    }),
+    SKF2 = hpr_skf:new(#{
+        route_id => RouteID, devaddr => DevAddr, session_key => SessionKey2, max_copies => 2
+    }),
+    ?assertEqual(ok, hpr_skf_storage:insert(SKF1)),
+
+    {ok, RouteETS0} = hpr_route_storage:lookup(RouteID),
+    SKFETS0 = ?MODULE:skf_ets(RouteETS0),
+
+    %% Replace the whole set: drop SKF1, add SKF2. Returns the previous size.
+    ?assertEqual({ok, 1}, hpr_skf_storage:replace_route(RouteID, [SKF2])),
+
+    {ok, RouteETS1} = hpr_route_storage:lookup(RouteID),
+    SKFETS1 = ?MODULE:skf_ets(RouteETS1),
+
+    %% The table reference is unchanged (mutated in place) and still alive.
+    ?assertEqual(SKFETS0, SKFETS1),
+    ?assert(erlang:is_list(ets:info(SKFETS0))),
+
+    %% Contents reflect the new set: SKF1 gone, SKF2 present.
+    SK2 = hpr_utils:hex_to_bin(SessionKey2),
+    ?assertEqual([{SK2, 2}], hpr_skf_storage:lookup(SKFETS1, DevAddr)),
+    ok.
+
+test_skf_tolerates_dead_table() ->
+    Route = hpr_route:test_new(#{
+        id => "11ea6dfd-3dce-4106-8980-d34007ab689b",
+        net_id => 0,
+        oui => 1,
+        server => #{
+            host => "lns1.testdomain.com",
+            port => 80,
+            protocol => {http_roaming, #{}}
+        },
+        max_copies => 1
+    }),
+    RouteID = hpr_route:id(Route),
+    ?assertEqual(ok, hpr_route_storage:insert(Route)),
+
+    DevAddr = 16#00000001,
+    SessionKey = hpr_utils:bin_to_hex_string(crypto:strong_rand_bytes(16)),
+    SKF = hpr_skf:new(#{
+        route_id => RouteID, devaddr => DevAddr, session_key => SessionKey, max_copies => 1
+    }),
+    ?assertEqual(ok, hpr_skf_storage:insert(SKF)),
+
+    {ok, RouteETS} = hpr_route_storage:lookup(RouteID),
+    SKFETS = ?MODULE:skf_ets(RouteETS),
+
+    %% Simulate a pre-existing dangling reference: destroy the skf table but
+    %% leave the route record pointing at it.
+    true = ets:delete(SKFETS),
+    ?assertEqual(undefined, ets:info(SKFETS)),
+
+    %% Read/clear paths tolerate the dead table instead of crashing with badarg.
+    ?assertEqual([], hpr_skf_storage:lookup_route(RouteID)),
+    ?assertEqual(0, hpr_skf_storage:count_route(RouteID)),
+    ?assertEqual(0, hpr_skf_storage:clear_route(RouteID)),
+
+    %% replace_route recovers by recreating the table, then applies the new set.
+    SessionKey2 = hpr_utils:bin_to_hex_string(crypto:strong_rand_bytes(16)),
+    SKF2 = hpr_skf:new(#{
+        route_id => RouteID, devaddr => DevAddr, session_key => SessionKey2, max_copies => 3
+    }),
+    ?assertEqual({ok, 0}, hpr_skf_storage:replace_route(RouteID, [SKF2])),
+
+    {ok, RouteETS2} = hpr_route_storage:lookup(RouteID),
+    SKFETS2 = ?MODULE:skf_ets(RouteETS2),
+    ?assert(erlang:is_list(ets:info(SKFETS2))),
+    SK2 = hpr_utils:hex_to_bin(SessionKey2),
+    ?assertEqual([{SK2, 3}], hpr_skf_storage:lookup(SKFETS2, DevAddr)),
     ok.
 
 test_select_skf() ->

--- a/src/grpc/iot_config/hpr_skf_storage.erl
+++ b/src/grpc/iot_config/hpr_skf_storage.erl
@@ -12,6 +12,7 @@
     select/1, select/2,
 
     delete_route/1,
+    clear_route/1,
     replace_route/2,
     lookup_route/1,
     count_route/1,
@@ -211,8 +212,18 @@ delete_route(RouteID) ->
     case hpr_route_storage:lookup(RouteID) of
         {ok, RouteETS} ->
             SKFETS = hpr_route_ets:skf_ets(RouteETS),
-            Size = ets:info(SKFETS, size),
-            ets:delete(SKFETS),
+            %% The skf table can be gone already (e.g. a dangling reference left
+            %% over from a partial supervisor restart). ets:info/2 returns
+            %% `undefined` for a dead table, but ets:delete/1 would raise badarg,
+            %% so guard it and treat a missing table as already deleted.
+            Size =
+                case ets:info(SKFETS, size) of
+                    undefined ->
+                        0;
+                    S ->
+                        true = ets:delete(SKFETS),
+                        S
+                end,
             DetsFilename = ?MODULE:dets_filename(RouteID),
             _ = file:delete(DetsFilename),
             Size;
@@ -230,30 +241,78 @@ delete_route(RouteID) ->
             Err
     end.
 
+%% @doc Empty a route's SKF table in place without destroying it.
+%%
+%% Used when deactivating a route: the SKFs are dropped but the route record
+%% (and its `skf_ets' reference) is kept. Destroying the table here would leave
+%% the kept route record pointing at a dead table (a dangling reference), so we
+%% clear the contents in place instead and remove the persisted DETS file.
+-spec clear_route(hpr_route:id()) -> non_neg_integer().
+clear_route(RouteID) ->
+    case hpr_route_storage:lookup(RouteID) of
+        {ok, RouteETS} ->
+            SKFETS = hpr_route_ets:skf_ets(RouteETS),
+            Size =
+                case ets:info(SKFETS, size) of
+                    undefined ->
+                        0;
+                    S ->
+                        true = ets:delete_all_objects(SKFETS),
+                        S
+                end,
+            _ = file:delete(?MODULE:dets_filename(RouteID)),
+            Size;
+        {error, not_found} ->
+            _ = file:delete(?MODULE:dets_filename(RouteID)),
+            0
+    end.
+
+%% @doc Replace a route's full SKF set, mutating the existing table in place.
+%%
+%% The `skf_ets' table reference stored in the route record is created once (at
+%% route creation) and must stay valid for the route's whole lifetime. We never
+%% create a new table or rewrite the record's `skf_ets' field here, otherwise a
+%% concurrent read-modify-write from another process (e.g. a CLI `route sync')
+%% could write back a stale reference to a table we just deleted.
+%%
+%% New entries are inserted/overwritten first and stale keys deleted after, so
+%% the table is always a superset of the old and new sets during the update and
+%% never transiently missing a currently-valid key.
 -spec replace_route(hpr_route:id(), list(hpr_skf:skf())) ->
     {ok, non_neg_integer()} | {error, any()}.
 replace_route(RouteID, NewSKFs) ->
     case hpr_route_storage:lookup(RouteID) of
         {ok, RouteETS} ->
-            OldTab = hpr_route_ets:skf_ets(RouteETS),
-            NewTab = ets:new(?ETS_SKFS, [
-                public,
-                set,
-                {read_concurrency, true},
-                {write_concurrency, true},
-                {heir, erlang:whereis(?SKF_HEIR), RouteID}
-            ]),
-            lists:foreach(fun(SKF) -> ok = do_insert_skf(NewTab, SKF) end, NewSKFs),
+            %% Recover from a pre-existing dangling reference: if the table is
+            %% already gone, recreate it once. This is a controlled single-writer
+            %% re-creation (replace_route only runs in the stream worker).
+            {SKFETS, OldSize} =
+                case ets:info(hpr_route_ets:skf_ets(RouteETS), size) of
+                    undefined ->
+                        Tab = hpr_skf_storage:make_ets(RouteID),
+                        ok = hpr_route_storage:insert(
+                            hpr_route_ets:route(RouteETS),
+                            Tab,
+                            hpr_route_ets:backoff(RouteETS)
+                        ),
+                        {Tab, 0};
+                    S ->
+                        {hpr_route_ets:skf_ets(RouteETS), S}
+                end,
 
-            ok = hpr_route_storage:insert(
-                hpr_route_ets:route(RouteETS),
-                NewTab,
-                hpr_route_ets:backoff(RouteETS)
+            ok = lists:foreach(fun(SKF) -> ok = do_insert_skf(SKFETS, SKF) end, NewSKFs),
+
+            NewKeys = sets:from_list([new_skf_key(SKF) || SKF <- NewSKFs]),
+            CurrentKeys = ets:select(SKFETS, [{{'$1', '_'}, [], ['$1']}]),
+            lists:foreach(
+                fun(Key) ->
+                    case sets:is_element(Key, NewKeys) of
+                        true -> ok;
+                        false -> true = ets:delete(SKFETS, Key)
+                    end
+                end,
+                CurrentKeys
             ),
-
-            OldSize = ets:info(OldTab, size),
-
-            true = ets:delete(OldTab),
             {ok, OldSize};
         Other ->
             {error, Other}
@@ -265,7 +324,12 @@ lookup_route(RouteID) ->
     case hpr_route_storage:lookup(RouteID) of
         {ok, RouteETS} ->
             SKFETS = hpr_route_ets:skf_ets(RouteETS),
-            ets:tab2list(SKFETS);
+            %% Tolerate a dangling reference: ets:tab2list/1 would raise badarg
+            %% on a dead table.
+            case ets:info(SKFETS, size) of
+                undefined -> [];
+                _ -> ets:tab2list(SKFETS)
+            end;
         {error, not_found} ->
             []
     end.
@@ -275,9 +339,12 @@ count_route(RouteID) ->
     case hpr_route_storage:lookup(RouteID) of
         {ok, RouteETS} ->
             SKFETS = hpr_route_ets:skf_ets(RouteETS),
-            ets:info(SKFETS, size);
+            case ets:info(SKFETS, size) of
+                undefined -> 0;
+                Size -> Size
+            end;
         {error, not_found} ->
-            []
+            0
     end.
 
 %% -------------------------------------------------------------------
@@ -297,6 +364,21 @@ do_insert_skf(SKFETS, SKF) ->
             lager:warning("failed to insert ~p ~p", [{{SessionKey, DevAddr}, MaxCopies}, _R])
     end,
     ok.
+
+%% @doc The ETS key for an SKF, matching the entry inserted by do_insert_skf/2.
+%% Returns `undefined' for a malformed session key (which do_insert_skf/2 skips),
+%% a harmless sentinel that never matches a real key.
+-spec new_skf_key(hpr_skf:skf()) -> {binary(), non_neg_integer()} | undefined.
+new_skf_key(SKF) ->
+    DevAddr = hpr_skf:devaddr(SKF),
+    SessionKey = hpr_skf:session_key(SKF),
+    try hpr_utils:hex_to_bin(SessionKey) of
+        SessionKeyBin ->
+            {SessionKeyBin, DevAddr}
+    catch
+        _E:_R ->
+            undefined
+    end.
 
 -spec skf_md(hpr_route:id(), hpr_skf:skf()) -> proplists:proplist().
 skf_md(RouteID, SKF) ->

--- a/test/hpr_route_stream_worker_SUITE.erl
+++ b/test/hpr_route_stream_worker_SUITE.erl
@@ -638,6 +638,10 @@ refresh_route_test(_Config) ->
     {ok, RouteETS2} = hpr_route_storage:lookup(Route1ID),
     SKFETS2 = hpr_route_ets:skf_ets(RouteETS2),
 
+    %% Refresh mutates the skf table in place, so its identity is preserved.
+    %% A new table here would mean a window where a dangling reference can form.
+    ?assertEqual(SKFETS1, SKFETS2),
+
     %% Old routing is removed
     ?assertMatch([RouteETS2], hpr_devaddr_range_storage:lookup(16#00000005)),
     ?assertEqual([RouteETS2], hpr_eui_pair_storage:lookup(1, 12)),
@@ -684,6 +688,8 @@ refresh_route_test(_Config) ->
     %% Everything was removed
     {ok, RouteETS3} = hpr_route_storage:lookup(Route1ID),
     SKFETS3 = hpr_route_ets:skf_ets(RouteETS3),
+    %% Emptying the set also keeps the same table (cleared in place, not destroyed).
+    ?assertEqual(SKFETS2, SKFETS3),
     ?assertMatch([], hpr_devaddr_range_storage:lookup(16#00000005)),
     ?assertEqual([], hpr_eui_pair_storage:lookup(1, 12)),
     ?assertEqual([], hpr_eui_pair_storage:lookup(1, 100)),


### PR DESCRIPTION
## Problem

`hpr config route sync` (and other route operations) crash with `badarg` from `ets:delete/1`:

```
{badarg, [{ets,delete,[#Ref<...>], ...},
          {hpr_skf_storage,delete_route,1, ...},
          {hpr_route_storage,delete,1, ...}, ...]}
```

A route's per-route SKF table is referenced by the `skf_ets` field of its `hpr_routes_ets` record. Two code paths left that reference pointing at an already-deleted ETS table (a dangling reference). `ets:info/2` tolerates a dead table, but `ets:delete/1`/`ets:tab2list/1` raise `badarg`, aborting the whole operation.

### Root causes

1. **Deactivation (deterministic).** `hpr_cli_config:set_routes_active/2` deactivate branch re-inserts the route record (keeping its `skf_ets`) and then calls `hpr_skf_storage:delete_route/1`, which **destroys** the SKF table but, by design, keeps the route record. Every `route deactivate` / `oui deactivate` leaves a dangling reference; the next `route sync` / `route activate` trips over it.

2. **Concurrency race.** `hpr_skf_storage:replace_route/2` (run in the stream-worker gen_server) created a new table, swapped the record's `skf_ets` to it, and deleted the old table. Meanwhile `hpr_route_storage:insert/1` does a non-atomic read-modify-write of the same field and also runs in CLI/console processes. Interleaving lets the CLI write back a stale reference to the table the gen_server just deleted. `route sync` triggers both sides at once.

## Fix

Enforce the invariant that **a route's `skf_ets` table is created once and stays valid for the route's entire lifetime; only full route deletion destroys it.**

- New `hpr_skf_storage:clear_route/1` empties the SKF table in place (and removes the DETS file) without destroying it; used by the deactivate path instead of `delete_route/1`.
- `replace_route/2` now mutates the existing table in place via a diff (insert/overwrite new entries first, then delete stale keys) instead of create-swap-delete. The `skf_ets` field is never reassigned, so the race cannot produce a dangling reference. Insert-before-delete keeps the table a superset during the update, so packet SKF matching never transiently misses a valid key.
- Defensive guards in `delete_route/1`, `lookup_route/1`, and `count_route/1` tolerate an already-dead table so any pre-existing dangling references degrade gracefully (they self-heal on the next restart, which rebuilds SKF tables from DETS). `replace_route/2` also recreates the table if it finds it already gone. Also fixes `count_route/1` returning `[]` instead of `0` on `not_found`.

## Tests

- `hpr_route_ets` eunit: new `test_replace_route_keeps_table` (asserts table identity preserved + correct contents across a replace) and `test_skf_tolerates_dead_table` (asserts read/clear/replace paths survive a destroyed table).
- `hpr_route_stream_worker_SUITE` `refresh_route_test`: added assertions that the SKF table identity is preserved across refreshes.

### Verification

`compile`, `eunit`, `ct` (stream_worker + cli_config suites), `xref`, `format --verify`, and `dialyzer` all pass.