### PR TITLE
Add gateway denylist to drop uplinks from specific gateways

### DIFF
--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -30,6 +30,16 @@ trace app_eui <app_eui>         - Trace App EUI (ex: B216CDC4ABB9437)
 trace dev_eui <dev_eui>         - Trace Dev EUI (ex: B216CDC4ABB9437)
 ```
 
+`hpr denylist` Drop uplinks from specific gateways (in-memory, cleared on restart)
+```
+Usage:
+
+denylist ls                 - List denylisted gateways
+denylist add <gateway>      - Add a gateway (b58 address) to the denylist
+denylist remove <gateway>   - Remove a gateway (b58 address) from the denylist
+denylist reset              - Remove the entire denylist
+```
+
 `hpr config`
 
 ```

--- a/src/cli/hpr_cli_denylist.erl
+++ b/src/cli/hpr_cli_denylist.erl
@@ -1,0 +1,112 @@
+%%%-------------------------------------------------------------------
+%% @doc hpr_cli_denylist
+%%
+%% CLI to manage the ephemeral gateway denylist (see hpr_denylist).
+%% @end
+%%%-------------------------------------------------------------------
+-module(hpr_cli_denylist).
+
+-behavior(clique_handler).
+
+-export([register_cli/0]).
+
+register_cli() ->
+    register_all_usage(),
+    register_all_cmds().
+
+register_all_usage() ->
+    lists:foreach(fun(Args) -> apply(clique, register_usage, Args) end, [denylist_usage()]).
+
+register_all_cmds() ->
+    lists:foreach(fun(Cmds) -> [apply(clique, register_command, Cmd) || Cmd <- Cmds] end,
+                  [denylist_cmd()]).
+
+%%--------------------------------------------------------------------
+%% Denylist
+%%--------------------------------------------------------------------
+
+denylist_usage() ->
+    [["denylist"],
+     ["\n\n",
+      "denylist ls                 - List denylisted gateways\n",
+      "denylist add <gateway>      - Add a gateway (b58 address) to "
+      "the denylist\n",
+      "denylist remove <gateway>   - Remove a gateway (b58 address) "
+      "from the denylist\n",
+      "denylist reset              - Remove the entire denylist\n"]].
+
+denylist_cmd() ->
+    [[["denylist", "ls"], [], [], fun denylist_list/3],
+     [["denylist", "add", '*'], [], [], fun denylist_add/3],
+     [["denylist", "remove", '*'], [], [], fun denylist_remove/3],
+     [["denylist", "reset"], [], [], fun denylist_reset/3]].
+
+denylist_list(["denylist", "ls"], [], []) ->
+    case hpr_denylist:list() of
+        [] ->
+            c_text("Denylist is empty");
+        Gateways ->
+            Rows =
+                lists:map(fun(Gateway) ->
+                             B58 = libp2p_crypto:bin_to_b58(Gateway),
+                             [{" Gateway ", B58}, {" Name ", hpr_utils:gateway_name(B58)}]
+                          end,
+                          Gateways),
+            c_table(Rows)
+    end;
+denylist_list(_, _, _) ->
+    usage.
+
+denylist_add(["denylist", "add", GatewayStr], [], []) ->
+    case parse_gateway(GatewayStr) of
+        {ok, Gateway} ->
+            ok = hpr_denylist:add(Gateway),
+            c_text("Added ~s to denylist", [GatewayStr]);
+        error ->
+            c_text("Invalid gateway address: ~s", [GatewayStr])
+    end;
+denylist_add(_, _, _) ->
+    usage.
+
+denylist_remove(["denylist", "remove", GatewayStr], [], []) ->
+    case parse_gateway(GatewayStr) of
+        {ok, Gateway} ->
+            ok = hpr_denylist:remove(Gateway),
+            c_text("Removed ~s from denylist", [GatewayStr]);
+        error ->
+            c_text("Invalid gateway address: ~s", [GatewayStr])
+    end;
+denylist_remove(_, _, _) ->
+    usage.
+
+denylist_reset(["denylist", "reset"], [], []) ->
+    Count = hpr_denylist:count(),
+    ok = hpr_denylist:reset(),
+    c_text("Removed denylist (~p gateways)", [Count]);
+denylist_reset(_, _, _) ->
+    usage.
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+-spec parse_gateway(string()) -> {ok, binary()} | error.
+parse_gateway(GatewayStr) ->
+    try
+        {ok, libp2p_crypto:b58_to_bin(GatewayStr)}
+    catch
+        _E:_R ->
+            error
+    end.
+
+-spec c_text(string()) -> clique_status:status().
+c_text(T) ->
+    [clique_status:text([T])].
+
+-spec c_text(string(), [term()]) -> clique_status:status().
+c_text(F, Args) ->
+    c_text(io_lib:format(F, Args)).
+
+-spec c_table([proplists:proplist()]) -> clique_status:status().
+c_table(PropLists) ->
+    [clique_status:table(PropLists)].

--- a/src/cli/hpr_cli_registry.erl
+++ b/src/cli/hpr_cli_registry.erl
@@ -3,7 +3,8 @@
 -define(CLI_MODULES, [
     hpr_cli_config,
     hpr_cli_info,
-    hpr_cli_trace
+    hpr_cli_trace,
+    hpr_cli_denylist
 ]).
 
 -export([register_cli/0]).

--- a/src/hpr_denylist.erl
+++ b/src/hpr_denylist.erl
@@ -1,0 +1,177 @@
+%% @doc Ephemeral gateway denylist.
+%%
+%% Gateways (identified by their libp2p `pubkey_bin') on this list have their
+%% uplinks dropped by hpr_routing during packet validation. The backing ETS
+%% table does not exist by default and is created lazily on the first `add/1';
+%% `reset/0' removes it entirely. The denylist is in-memory only and is cleared
+%% on restart.
+%%
+%% Because the table is usually created from a transient CLI/RPC process, it is
+%% given `hpr_sup' as its heir so ownership survives that process exiting.
+-module(hpr_denylist).
+
+-export([
+    is_denied/1,
+    add/1,
+    remove/1,
+    reset/0,
+    list/0,
+    count/0
+]).
+
+-define(DENYLIST, hpr_gateway_denylist_ets).
+-define(HEIR, hpr_sup).
+
+-spec is_denied(Gateway :: binary()) -> boolean().
+is_denied(Gateway) ->
+    case ets:whereis(?DENYLIST) of
+        undefined -> false;
+        _ -> ets:member(?DENYLIST, Gateway)
+    end.
+
+-spec add(Gateway :: binary()) -> ok.
+add(Gateway) ->
+    Tab = ensure_table(),
+    true = ets:insert(Tab, {Gateway}),
+    ok.
+
+-spec remove(Gateway :: binary()) -> ok.
+remove(Gateway) ->
+    case ets:whereis(?DENYLIST) of
+        undefined -> ok;
+        _ -> true = ets:delete(?DENYLIST, Gateway)
+    end,
+    ok.
+
+-spec reset() -> ok.
+reset() ->
+    case ets:whereis(?DENYLIST) of
+        undefined -> ok;
+        _ -> true = ets:delete(?DENYLIST)
+    end,
+    ok.
+
+-spec list() -> [binary()].
+list() ->
+    case ets:whereis(?DENYLIST) of
+        undefined -> [];
+        _ -> [Gateway || {Gateway} <- ets:tab2list(?DENYLIST)]
+    end.
+
+-spec count() -> non_neg_integer().
+count() ->
+    case ets:info(?DENYLIST, size) of
+        undefined -> 0;
+        Size -> Size
+    end.
+
+%% ------------------------------------------------------------------
+%% Internal Functions
+%% ------------------------------------------------------------------
+
+%% @doc Return the denylist table, creating it if needed.
+%%
+%% The table is given `hpr_sup' as its heir so it outlives the (often transient)
+%% process that first creates it. When `hpr_sup' is not running (e.g. in tests)
+%% it is created with no heir.
+-spec ensure_table() -> ets:table().
+ensure_table() ->
+    case ets:whereis(?DENYLIST) of
+        undefined ->
+            Heir =
+                case erlang:whereis(?HEIR) of
+                    undefined -> {heir, none};
+                    Pid -> {heir, Pid, undefined}
+                end,
+            try
+                ets:new(?DENYLIST, [
+                    public,
+                    named_table,
+                    set,
+                    {read_concurrency, true},
+                    Heir
+                ])
+            catch
+                %% Another process created it between the whereis and the new.
+                error:badarg -> ?DENYLIST
+            end;
+        _ ->
+            ?DENYLIST
+    end.
+
+%% ------------------------------------------------------------------
+%% EUNIT Tests
+%% ------------------------------------------------------------------
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+all_test_() ->
+    {foreach, fun foreach_setup/0, fun foreach_cleanup/1, [
+        ?_test(test_missing_table()),
+        ?_test(test_add_remove()),
+        ?_test(test_reset())
+    ]}.
+
+foreach_setup() ->
+    ok.
+
+foreach_cleanup(ok) ->
+    _ = catch ets:delete(?DENYLIST),
+    ok.
+
+%% By default the table does not exist; reads are safe and report "not denied".
+test_missing_table() ->
+    Gateway = <<"gw1">>,
+    ?assertEqual(undefined, ets:whereis(?DENYLIST)),
+    ?assertEqual(false, ?MODULE:is_denied(Gateway)),
+    ?assertEqual([], ?MODULE:list()),
+    ?assertEqual(0, ?MODULE:count()),
+    %% remove/reset are no-ops when the table is missing
+    ?assertEqual(ok, ?MODULE:remove(Gateway)),
+    ?assertEqual(ok, ?MODULE:reset()),
+    ?assertEqual(undefined, ets:whereis(?DENYLIST)),
+    ok.
+
+test_add_remove() ->
+    Gateway1 = <<"gw1">>,
+    Gateway2 = <<"gw2">>,
+
+    %% add lazily creates the table (with the {heir, none} fallback since hpr_sup
+    %% is not running under eunit)
+    ?assertEqual(ok, ?MODULE:add(Gateway1)),
+    ?assertNotEqual(undefined, ets:whereis(?DENYLIST)),
+    ?assert(?MODULE:is_denied(Gateway1)),
+    ?assertEqual(false, ?MODULE:is_denied(Gateway2)),
+    ?assertEqual(1, ?MODULE:count()),
+
+    ?assertEqual(ok, ?MODULE:add(Gateway2)),
+    ?assertEqual(2, ?MODULE:count()),
+    ?assertEqual(lists:sort([Gateway1, Gateway2]), lists:sort(?MODULE:list())),
+
+    %% adding the same gateway again is idempotent
+    ?assertEqual(ok, ?MODULE:add(Gateway1)),
+    ?assertEqual(2, ?MODULE:count()),
+
+    ?assertEqual(ok, ?MODULE:remove(Gateway1)),
+    ?assertEqual(false, ?MODULE:is_denied(Gateway1)),
+    ?assert(?MODULE:is_denied(Gateway2)),
+    ?assertEqual(1, ?MODULE:count()),
+    ok.
+
+test_reset() ->
+    Gateway = <<"gw1">>,
+    ?assertEqual(ok, ?MODULE:add(Gateway)),
+    ?assert(?MODULE:is_denied(Gateway)),
+
+    %% reset removes the whole table
+    ?assertEqual(ok, ?MODULE:reset()),
+    ?assertEqual(undefined, ets:whereis(?DENYLIST)),
+    ?assertEqual(false, ?MODULE:is_denied(Gateway)),
+
+    %% add after reset recreates it
+    ?assertEqual(ok, ?MODULE:add(Gateway)),
+    ?assert(?MODULE:is_denied(Gateway)),
+    ok.
+
+-endif.

--- a/src/hpr_routing.erl
+++ b/src/hpr_routing.erl
@@ -18,7 +18,8 @@
 
 -type hpr_routing_response() ::
     ok
-    | {error, gateway_limit_exceeded | invalid_packet_type | bad_signature | invalid_mic}.
+    | {error,
+        gateway_limit_exceeded | invalid_packet_type | bad_signature | invalid_mic | gateway_denied}.
 
 -type route() :: {hpr_route_ets:route(), SKFMaxCopies :: non_neg_integer()}.
 -type routes() :: list(route()).
@@ -44,6 +45,7 @@ handle_packet(PacketUp, Opts) ->
     Checks = [
         {fun packet_type_check/1, [], invalid_packet_type},
         {fun gateway_check/2, [Gateway], wrong_gateway},
+        {fun gateway_denied_check/1, [], gateway_denied},
         {fun packet_session_check/2, [SessionKey], bad_signature},
         {fun gateway_throttle_check/1, [], gateway_limit_exceeded},
         {fun packet_throttle_check/1, [], packet_limit_exceeded}
@@ -438,6 +440,15 @@ packet_type_check(PacketUp) ->
 gateway_check(PacketUp, Gateway) ->
     hpr_packet_up:gateway(PacketUp) == Gateway.
 
+%% Drop packets from denylisted gateways. The denylist is a cheap, usually-empty
+%% ETS lookup, so we run it before signature/throttle work. The gateway field is
+%% not signature-verified at this point, but that is fine for a denylist: a packet
+%% spoofing a denied gateway's key still fails packet_session_check downstream.
+-spec gateway_denied_check(PacketUp :: hpr_packet_up:packet()) ->
+    boolean().
+gateway_denied_check(PacketUp) ->
+    not hpr_denylist:is_denied(hpr_packet_up:gateway(PacketUp)).
+
 -spec packet_session_check(PacketUp :: hpr_packet_up:packet(), SessionKey :: undefined | binary()) ->
     boolean().
 packet_session_check(PacketUp, undefined) ->
@@ -494,7 +505,8 @@ all_test_() ->
         ?_test(maybe_deliver_packet_to_route_locked()),
         ?_test(maybe_deliver_packet_to_route_inactive()),
         ?_test(maybe_deliver_packet_to_route_in_cooldown()),
-        ?_test(maybe_deliver_packet_to_route_multi_buy())
+        ?_test(maybe_deliver_packet_to_route_multi_buy()),
+        ?_test(handle_packet_gateway_denied())
     ]}.
 
 foreach_setup() ->
@@ -529,9 +541,29 @@ foreach_cleanup(ok) ->
         ets:tab2list(hpr_routes_ets)
     ),
     true = ets:delete(hpr_routes_ets),
+    _ = (catch hpr_denylist:reset()),
     true = erlang:unregister(hpr_sup),
     meck:unload(hpr_gateway_location),
     meck:unload(hpr_metrics),
+    ok.
+
+handle_packet_gateway_denied() ->
+    meck:expect(hpr_metrics, observe_packet_up, fun(_, _, _, _) -> ok end),
+    %% handle_packet/2 calls hpr_packet_up:md/2 which reaches gproc; start it so
+    %% the md lookup returns "not found" (a warning) instead of crashing.
+    {ok, _} = application:ensure_all_started(gproc),
+
+    PacketUp = test_utils:uplink_packet_up(#{devaddr => 16#00000001}),
+    Gateway = hpr_packet_up:gateway(PacketUp),
+    Opts = #{gateway => Gateway},
+
+    %% Not denied by default: the denylist check passes and routing continues
+    %% (the test packet then fails on its bad signature, not gateway_denied).
+    ?assertNotEqual({error, gateway_denied}, hpr_routing:handle_packet(PacketUp, Opts)),
+
+    %% Once denied, the packet is dropped with gateway_denied.
+    ok = hpr_denylist:add(Gateway),
+    ?assertEqual({error, gateway_denied}, hpr_routing:handle_packet(PacketUp, Opts)),
     ok.
 
 find_routes_for_uplink_no_skf() ->


### PR DESCRIPTION
## Problem

Operators occasionally need to stop routing uplinks from a specific gateway (an abusive or misbehaving hotspot) without waiting on a Config Service change. `hpr_routing:handle_packet/2` runs a fixed set of validation checks and has no notion of a blocked gateway.

## Change

Adds an in-memory gateway denylist, a routing check that drops denylisted gateways, and a CLI to manage the list.

- **`hpr_denylist`** (new) — owns an ETS table keyed by gateway `pubkey_bin`. The table **does not exist by default** and is created lazily on the first `add/1`; `reset/0` removes it entirely. It is given `hpr_sup` as its heir so it survives the transient CLI/RPC process that creates it (with a `{heir, none}` fallback when `hpr_sup` isn't running, e.g. in tests). All reads tolerate a missing table. API: `is_denied/1`, `add/1`, `remove/1`, `reset/0`, `list/0`, `count/0`.
- **`hpr_routing`** — `handle_packet/2` gains `gateway_denied_check/1` (added to the `Checks` list right after `gateway_check`), returning `{error, gateway_denied}` for denylisted gateways. It's a cheap ETS lookup placed before the signature/throttle checks. `gateway_denied` is added to the `hpr_routing_response()` type and is recorded by metrics automatically.
- **`hpr_cli_denylist`** (new, registered in `hpr_cli_registry`) — `hpr denylist ls | add <gateway> | remove <gateway> | reset`. Gateways are given as base58 addresses (parsed via `libp2p_crypto:b58_to_bin/1`, with invalid input reported gracefully).
- **`docs/playbook.md`** — documents the new commands.

The denylist is **ephemeral** (ETS only) and is cleared on restart.

## Tests

- `hpr_denylist` eunit: missing-table reads are safe, add/remove/`is_denied`, idempotent add, reset removes the table, add-after-reset recreates it, and the `{heir, none}` fallback path.
- `hpr_routing` eunit: a packet from a denylisted gateway returns `{error, gateway_denied}`; a non-denied gateway passes the check.

### Verification

`rebar3 compile` clean; full `rebar3 eunit` — **177 tests, 0 failures**.

> Note: `rebar3 eunit --module=hpr_routing` in isolation hangs, but this is pre-existing (reproduces on `main`); the in-module routing tests rely on environment the full suite sets up. Run the full `rebar3 eunit`.