### PR TITLE
Harden custom multi-buy on restart and start packet router server under hpr_sup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ compile: | $(grpc_services_directory)
 	$(REBAR) format
 
 clean:
-	git clean -dXfffffffffff
+	rm -rf src/grpc/autogen/
+	rm -rf _build/
 
 test: | $(grpc_services_directory)
 	$(REBAR) fmt --verbose --check rebar.config

--- a/config/ct.config
+++ b/config/ct.config
@@ -40,7 +40,32 @@
         {multi_buy_enabled, true},
         {routing_cache_window_secs, 5},
         {routing_cache_timeout_secs, 10},
-        {ics_stream_worker_checkpoint_secs, 3}
+        {ics_stream_worker_checkpoint_secs, 3},
+        %% Packet router GRPC server, started under hpr_sup (last child) rather
+        %% than auto-started by grpcbox. The grpcbox `servers' below keep only
+        %% the test mock services.
+        {packet_router_server, #{
+            grpc_opts => #{
+                service_protos => [packet_router_pb],
+                services => #{
+                    'helium.packet_router.packet' => hpr_packet_router_service
+                }
+            },
+            transport_opts => #{ssl => false},
+            listen_opts => #{
+                port => 8080,
+                ip => {0, 0, 0, 0}
+            },
+            pool_opts => #{size => 500},
+            server_opts => #{
+                header_table_size => 4096,
+                enable_push => 1,
+                max_concurrent_streams => unlimited,
+                initial_window_size => 65535,
+                max_frame_size => 16384,
+                max_header_list_size => unlimited
+            }
+        }}
     ]},
     {aws_credentials, [
         {credential_providers, [aws_credentials_env]},
@@ -51,30 +76,9 @@
     {grpcbox, [
         %% default_channel is used by the test gateway.
         {client, #{channels => [{default_channel, [{http, "localhost", 8080, []}], #{}}]}},
-        %% This is default GRPC Server to get data from hotspots
+        %% Test mock services. The packet router server (8080) is started by
+        %% hpr_sup from {hpr, packet_router_server}, not here.
         {servers, [
-            #{
-                grpc_opts => #{
-                    service_protos => [packet_router_pb],
-                    services => #{
-                        'helium.packet_router.packet' => hpr_packet_router_service
-                    }
-                },
-                transport_opts => #{ssl => false},
-                listen_opts => #{
-                    port => 8080,
-                    ip => {0, 0, 0, 0}
-                },
-                pool_opts => #{size => 500},
-                server_opts => #{
-                    header_table_size => 4096,
-                    enable_push => 1,
-                    max_concurrent_streams => unlimited,
-                    initial_window_size => 65535,
-                    max_frame_size => 16384,
-                    max_header_list_size => unlimited
-                }
-            },
             %% IOT Config Service
             #{
                 grpc_opts => #{

--- a/config/sys.config
+++ b/config/sys.config
@@ -29,6 +29,30 @@
             transport => http,
             host => "localhost",
             port => 8081
+        }},
+        %% Packet router GRPC server. Started under hpr_sup as the last child so
+        %% we don't accept gateway connections before HPR is fully initialized.
+        {packet_router_server, #{
+            grpc_opts => #{
+                service_protos => [packet_router_pb],
+                services => #{
+                    'helium.packet_router.packet' => hpr_packet_router_service
+                }
+            },
+            transport_opts => #{ssl => false},
+            listen_opts => #{
+                port => 8080,
+                ip => {0, 0, 0, 0}
+            },
+            pool_opts => #{size => 500},
+            server_opts => #{
+                header_table_size => 4096,
+                enable_push => 1,
+                max_concurrent_streams => unlimited,
+                initial_window_size => 16777216,
+                max_frame_size => 16384,
+                max_header_list_size => unlimited
+            }
         }}
     ]},
     {aws_credentials, [
@@ -42,32 +66,9 @@
         {client_initial_window_size, 16777216},
         {server_initial_window_size, 16777216}
     ]},
-    {grpcbox, [
-        {servers, [
-            #{
-                grpc_opts => #{
-                    service_protos => [packet_router_pb],
-                    services => #{
-                        'helium.packet_router.packet' => hpr_packet_router_service
-                    }
-                },
-                transport_opts => #{ssl => false},
-                listen_opts => #{
-                    port => 8080,
-                    ip => {0, 0, 0, 0}
-                },
-                pool_opts => #{size => 500},
-                server_opts => #{
-                    header_table_size => 4096,
-                    enable_push => 1,
-                    max_concurrent_streams => unlimited,
-                    initial_window_size => 16777216,
-                    max_frame_size => 16384,
-                    max_header_list_size => unlimited
-                }
-            }
-        ]}
-    ]},
+    %% The packet router GRPC server is no longer auto-started by grpcbox here;
+    %% it is started as the last child of hpr_sup (see {hpr, packet_router_server}).
+    {grpcbox, []},
     {lager, [
         {suppress_supervisor_start_stop, true},
         {log_root, "/var/log/hpr"},

--- a/config/sys.config.src
+++ b/config/sys.config.src
@@ -51,6 +51,30 @@
             host => "${HPR_MULTI_BUY_SERVICE_HOST}",
             port => "${HPR_MULTI_BUY_SERVICE_PORT}"
         }},
+        %% Packet router GRPC server. Started under hpr_sup as the last child so
+        %% we don't accept gateway connections before HPR is fully initialized.
+        {packet_router_server, #{
+            grpc_opts => #{
+                service_protos => [packet_router_pb],
+                services => #{
+                    'helium.packet_router.packet' => hpr_packet_router_service
+                }
+            },
+            transport_opts => #{ssl => false},
+            listen_opts => #{
+                port => 8080,
+                ip => {0, 0, 0, 0}
+            },
+            pool_opts => #{size => 500},
+            server_opts => #{
+                header_table_size => 4096,
+                enable_push => 1,
+                max_concurrent_streams => unlimited,
+                initial_window_size => 16777216,
+                max_frame_size => 16384,
+                max_header_list_size => unlimited
+            }
+        }},
         {routing_cache_timeout_secs, 15},
         {routing_cache_window_secs, 120},
         {devaddr_cache_ttl_ms, 43200000},
@@ -67,33 +91,9 @@
         {client_initial_window_size, 16777216},
         {server_initial_window_size, 16777216}
     ]},
-    {grpcbox, [
-        {listen_opts, #{port => 8080, ip => {0, 0, 0, 0}}},
-        {servers, [
-            #{
-                grpc_opts => #{
-                    service_protos => [packet_router_pb],
-                    services => #{
-                        'helium.packet_router.packet' => hpr_packet_router_service
-                    }
-                },
-                transport_opts => #{ssl => false},
-                listen_opts => #{
-                    port => 8080,
-                    ip => {0, 0, 0, 0}
-                },
-                pool_opts => #{size => 500},
-                server_opts => #{
-                    header_table_size => 4096,
-                    enable_push => 1,
-                    max_concurrent_streams => unlimited,
-                    initial_window_size => 16777216,
-                    max_frame_size => 16384,
-                    max_header_list_size => unlimited
-                }
-            }
-        ]}
-    ]},
+    %% The packet router GRPC server is no longer auto-started by grpcbox here;
+    %% it is started as the last child of hpr_sup (see {hpr, packet_router_server}).
+    {grpcbox, []},
     {lager, [
         {suppress_supervisor_start_stop, true},
         {log_root, "/var/log/hpr"},

--- a/src/grpc/iot_config/hpr_route_stream_worker.erl
+++ b/src/grpc/iot_config/hpr_route_stream_worker.erl
@@ -480,7 +480,8 @@ terminate(_Reason, #state{checkpoint_timer = CheckpointTimer, stream = Stream} =
         | {skf, hpr_skf:skf()}
 ) -> ok.
 process_route_stream_res(add, {route, Route}) ->
-    hpr_route_storage:insert(Route);
+    ok = hpr_route_storage:insert(Route),
+    ok = hpr_multi_buy:init_channel(Route);
 process_route_stream_res(add, {eui_pair, EUIPair}) ->
     hpr_eui_pair_storage:insert(EUIPair);
 process_route_stream_res(add, {devaddr_range, DevAddrRange}) ->

--- a/src/hpr_multi_buy.erl
+++ b/src/hpr_multi_buy.erl
@@ -6,6 +6,7 @@
 
 -export([
     init/0,
+    init_channel/1,
     update_counter/5,
     cleanup/1,
     make_key/2,
@@ -62,6 +63,29 @@ update_counter(Key, Max, PubKeyBin, Region, Route) ->
             update_counter_default(Key, Max, B58PubKeyBin, Region);
         true ->
             update_counter_custom(Key, Max, B58PubKeyBin, Region, Route)
+    end.
+
+-spec init_channel(Route :: hpr_route:route()) -> ok.
+init_channel(Route) ->
+    %% Pre-warm the custom multi-buy grpc channel for a route so the first
+    %% uplinks (e.g. right after a restart) don't race a cold channel and pile
+    %% onto the 5s grpc timeout. No-op for default routes. Idempotent
+    %% (`ensure_channel' returns fast if the channel is already up) and
+    %% non-blocking so it never stalls boot or route processing.
+    case is_using_custom_multi_buy(Route) of
+        false ->
+            ok;
+        true ->
+            _ = erlang:spawn(fun() ->
+                _ = ensure_channel(
+                    make_channel_key(Route),
+                    hpr_route:multi_buy_protocol(Route),
+                    hpr_route:multi_buy_host(Route),
+                    hpr_route:multi_buy_port(Route),
+                    hpr_route:id(Route)
+                )
+            end),
+            ok
     end.
 
 -spec cleanup(Duration :: non_neg_integer()) -> ok.
@@ -222,8 +246,14 @@ request_custom(Key, B58PubKeyBin, Region, Route) ->
     RouteID = hpr_route:id(Route),
     Channel = make_channel_key(Route),
     FailOnUnavailable = hpr_route:multi_buy_fail_on_unavailable(Route),
-    case ensure_channel(Channel, Protocol, Host, Port, RouteID) of
-        ok ->
+    %% Only issue the grpc call once the channel actually has a ready connection.
+    %% Right after a restart the channel is cold: `ensure_channel' would connect
+    %% (sync_start) and return `ok' before the HTTP/2 connection is up, so every
+    %% request would then block on the 5s grpc timeout. Instead we fail fast and
+    %% start the channel in the background, which lets the caller's backoff engage
+    %% within milliseconds and short-circuit the rest of the burst.
+    case grpcbox_channel:pick(Channel, unary) of
+        {ok, _} ->
             {Time, Result} = timer:tc(fun() ->
                 Req = #multi_buy_inc_req_v1_pb{
                     key = hpr_utils:bin_to_hex_string(Key),
@@ -243,8 +273,9 @@ request_custom(Key, B58PubKeyBin, Region, Route) ->
             end),
             hpr_metrics:observe_multi_buy(RouteID, Result, Time),
             Result;
-        {error, ConnectReason} ->
-            {error, ConnectReason, FailOnUnavailable}
+        {error, _PickReason} ->
+            _ = ensure_channel(Channel, Protocol, Host, Port, RouteID),
+            {error, channel_not_ready, FailOnUnavailable}
     end.
 
 -spec ensure_channel(
@@ -368,7 +399,9 @@ all_test_() ->
         ?_test(test_update_counter_custom_denied()),
         ?_test(test_update_counter_custom_fail_on_unavailable()),
         ?_test(test_update_counter_custom_no_fail()),
-        ?_test(test_update_counter_custom_backoff())
+        ?_test(test_update_counter_custom_backoff()),
+        ?_test(test_update_counter_custom_channel_not_ready()),
+        ?_test(test_init_channel())
     ]}.
 
 foreach_setup() ->
@@ -658,6 +691,54 @@ test_update_counter_custom_backoff() ->
         {ok, false},
         ?MODULE:update_counter(Key, Max, ?TEST_HOTSPOT_KEY, ?TEST_REGION, Route)
     ),
+    ok.
+
+test_update_counter_custom_channel_not_ready() ->
+    Key = crypto:strong_rand_bytes(16),
+    Max = 3,
+    Route = ?TEST_CUSTOM_ROUTE(true),
+
+    %% Channel is cold (e.g. right after a restart): `pick' has no ready endpoint.
+    meck:expect(grpcbox_channel, pick, fun(_, _) -> {error, no_endpoints} end),
+    %% The grpc `inc' must never be called while the channel is cold: we fail fast
+    %% instead of blocking on the 5s grpc timeout.
+    meck:expect(helium_multi_buy_multi_buy_client, inc, fun(_, _) ->
+        error(should_not_be_called)
+    end),
+
+    ?assertEqual(
+        {error, ?FAIL_ON_UNAVAILABLE},
+        ?MODULE:update_counter(Key, Max, ?TEST_HOTSPOT_KEY, ?TEST_REGION, Route)
+    ),
+    ?assertEqual(0, meck:num_calls(helium_multi_buy_multi_buy_client, inc, 2)),
+
+    %% The first fast failure engages backoff, so the next request short-circuits
+    %% without even attempting to connect.
+    ?assert(is_in_backoff(make_channel_key(Route))),
+    ?assertEqual(
+        {error, ?FAIL_ON_UNAVAILABLE},
+        ?MODULE:update_counter(Key, Max, ?TEST_HOTSPOT_KEY, ?TEST_REGION, Route)
+    ),
+    ?assertEqual(0, meck:num_calls(helium_multi_buy_multi_buy_client, inc, 2)),
+    ok.
+
+test_init_channel() ->
+    %% Cold channel so `ensure_channel' has to connect.
+    meck:expect(grpcbox_channel, pick, fun(_, _) -> {error, no_endpoints} end),
+
+    %% Default route: nothing to pre-warm, no channel connect attempted.
+    ConnectsBefore = meck:num_calls(grpcbox_client, connect, ['_', '_', '_']),
+    ?assertEqual(ok, ?MODULE:init_channel(?TEST_ROUTE)),
+    timer:sleep(50),
+    ?assertEqual(
+        ConnectsBefore, meck:num_calls(grpcbox_client, connect, ['_', '_', '_'])
+    ),
+
+    %% Custom route with a cold channel: connected in the background.
+    Route = ?TEST_CUSTOM_ROUTE(false),
+    ?assertEqual(ok, ?MODULE:init_channel(Route)),
+    ok = meck:wait(grpcbox_client, connect, ['_', '_', '_'], timer:seconds(1)),
+    ?assert(meck:num_calls(grpcbox_client, connect, ['_', '_', '_']) > ConnectsBefore),
     ok.
 
 -endif.

--- a/src/hpr_sup.erl
+++ b/src/hpr_sup.erl
@@ -92,23 +92,28 @@ init([]) ->
         {port, metrics_port()}
     ],
 
-    ChildSpecs = [
-        ?WORKER(hpr_routing_cache, [#{}]),
-        ?WORKER(hpr_metrics, [#{}]),
-        ?ELLI_WORKER(hpr_metrics_handler, [ElliConfigMetrics]),
+    %% Packet router GRPC server config. Started as the LAST child below so we
+    %% don't accept gateway connections until the rest of HPR is initialized.
+    PacketRouterServerConfig = application:get_env(?APP, packet_router_server, #{}),
 
-        ?WORKER(hpr_packet_reporter, [PacketReporterConfig]),
-        ?WORKER(hpr_gateway_liveness_reporter, [LivenessReporterConfig]),
+    ChildSpecs =
+        [
+            ?WORKER(hpr_routing_cache, [#{}]),
+            ?WORKER(hpr_metrics, [#{}]),
+            ?ELLI_WORKER(hpr_metrics_handler, [ElliConfigMetrics]),
 
-        ?WORKER(hpr_route_stream_worker, [#{}]),
+            ?WORKER(hpr_packet_reporter, [PacketReporterConfig]),
+            ?WORKER(hpr_gateway_liveness_reporter, [LivenessReporterConfig]),
 
-        ?WORKER(hpr_protocol_router, [#{}]),
+            ?WORKER(hpr_route_stream_worker, [#{}]),
 
-        ?SUP(hpr_gwmp_sup, []),
+            ?WORKER(hpr_protocol_router, [#{}]),
 
-        ?SUP(hpr_http_roaming_sup, []),
-        ?WORKER(hpr_http_roaming_downlink_stream_worker, [#{}])
-    ],
+            ?SUP(hpr_gwmp_sup, []),
+
+            ?SUP(hpr_http_roaming_sup, []),
+            ?WORKER(hpr_http_roaming_downlink_stream_worker, [#{}])
+        ] ++ grpc_server_child_specs(PacketRouterServerConfig),
     {ok, {
         #{
             strategy => one_for_one,
@@ -144,6 +149,36 @@ normalize_port(Port) when is_list(Port) ->
 normalize_port(Port) ->
     lager:warning("bad ~p ~p, defaulting to ~w", [?METRICS_PORT, Port, ?DEFAULT_METRICS_PORT]),
     ?DEFAULT_METRICS_PORT.
+
+%% @doc Build the child spec for the packet router GRPC server.
+%%
+%% Historically this server was auto-started by the `grpcbox' application from
+%% its `servers' env, which happens before HPR is initialized — meaning we could
+%% accept gateway uplinks before the routing/multi-buy/ETS state was ready. We
+%% now start it ourselves as the last child of `hpr_sup' so the listener only
+%% comes up once everything else is in place.
+-spec grpc_server_child_specs(Config :: map()) -> [supervisor:child_spec()].
+grpc_server_child_specs(Config) when map_size(Config) =:= 0 ->
+    lager:error("no packet_router_server config, not starting grpc server"),
+    [];
+grpc_server_child_specs(Config) ->
+    GrpcOpts = maps:get(grpc_opts, Config, #{}),
+    ServerOpts = maps:get(server_opts, Config, #{}),
+    ListenOpts = maps:get(listen_opts, Config, #{}),
+    PoolOpts = maps:get(pool_opts, Config, #{}),
+    TransportOpts = maps:get(transport_opts, Config, #{}),
+    [
+        #{
+            id => grpcbox_services_sup,
+            start =>
+                {grpcbox_services_sup, start_link, [
+                    ServerOpts, GrpcOpts, ListenOpts, PoolOpts, TransportOpts
+                ]},
+            type => supervisor,
+            restart => permanent,
+            shutdown => 5000
+        }
+    ].
 
 maybe_start_channel(Config, ChannelName) ->
     case Config of

--- a/src/hpr_sup.erl
+++ b/src/hpr_sup.erl
@@ -80,6 +80,13 @@ init([]) ->
     _ = maybe_start_channel(DownlinkServiceConfig, ?DOWNLINK_CHANNEL),
     _ = maybe_start_multi_buy_channel(MultiBuyServiceConfig),
 
+    %% Pre-warm custom multi-buy channels for routes restored from disk so the
+    %% first uplinks after a restart don't race cold channels. Routes are already
+    %% hydrated into ETS by `hpr_route_ets:init/0' above.
+    ok = timing("multi buy custom channels", fun() ->
+        lists:foreach(fun hpr_multi_buy:init_channel/1, hpr_route_storage:all_routes())
+    end),
+
     ElliConfigMetrics = [
         {callback, hpr_metrics_handler},
         {port, metrics_port()}

--- a/test/hpr_sup_SUITE.erl
+++ b/test/hpr_sup_SUITE.erl
@@ -1,0 +1,57 @@
+-module(hpr_sup_SUITE).
+
+-export([
+    all/0,
+    init_per_testcase/2,
+    end_per_testcase/2
+]).
+
+-export([
+    packet_router_server_under_hpr_sup_test/1
+]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Registered name grpcbox gives the services supervisor for the packet router
+%% listener, derived from its listen_opts (ip 0.0.0.0, port 8080). See
+%% grpcbox_services_sup:services_sup_name/1.
+-define(PACKET_ROUTER_SERVICES_SUP, 'grpcbox_services_sup_0.0.0.0_8080').
+
+%%--------------------------------------------------------------------
+%% COMMON TEST CALLBACK FUNCTIONS
+%%--------------------------------------------------------------------
+
+all() ->
+    [
+        packet_router_server_under_hpr_sup_test
+    ].
+
+init_per_testcase(TestCase, Config) ->
+    test_utils:init_per_testcase(TestCase, Config).
+
+end_per_testcase(TestCase, Config) ->
+    test_utils:end_per_testcase(TestCase, Config).
+
+%%--------------------------------------------------------------------
+%% TEST CASES
+%%--------------------------------------------------------------------
+
+%% The packet router GRPC server must be supervised by hpr_sup (and not
+%% auto-started by the grpcbox application), so that the listener only comes up
+%% after the rest of HPR has been initialized. This guards against regressing
+%% the server back into grpcbox's own supervision tree.
+packet_router_server_under_hpr_sup_test(_Config) ->
+    Children = supervisor:which_children(hpr_sup),
+
+    %% hpr_sup starts the server under the child spec id `grpcbox_services_sup'.
+    Child = lists:keyfind(grpcbox_services_sup, 1, Children),
+    ?assertMatch({grpcbox_services_sup, _Pid, supervisor, _Modules}, Child),
+    {grpcbox_services_sup, Pid, supervisor, _} = Child,
+    ?assert(erlang:is_pid(Pid)),
+    ?assert(erlang:is_process_alive(Pid)),
+
+    %% And it must be the packet router listener on 0.0.0.0:8080, i.e. the same
+    %% process grpcbox registered for that port, proving hpr_sup owns it.
+    ?assertEqual(Pid, erlang:whereis(?PACKET_ROUTER_SERVICES_SUP)),
+
+    ok.


### PR DESCRIPTION
## What & why

Two related restart/startup robustness fixes, plus a build tidy-up.

### 1. Prevent custom multi-buy error storms on restart (`ee88364`)
After a restart, custom multi-buy routes start with cold gRPC channels and an empty backoff table. A burst of concurrent uplinks all pass the backoff gate before any single request fails, and each then blocks on the 5s gRPC timeout against the not-yet-connected channel — producing an error spike until the channels warm up.

- `request_custom` now checks readiness with `grpcbox_channel:pick` and **fails fast** (starting the channel in the background) instead of issuing a doomed 5s call, so backoff engages within milliseconds and the rest of the burst short-circuits.
- **Pre-warm** custom multi-buy channels at startup for routes restored from disk (`hpr_sup`), and when routes are added over the config stream (`hpr_route_stream_worker`), so the first uplinks usually hit an already-connected channel.
- Adds `init_channel/1` plus eunit coverage (cold-channel fail-fast, background connect).

### 2. Start packet router GRPC server under `hpr_sup` (`ecef825`)
The inbound packet router server was auto-started by the `grpcbox` application from its `servers` env — which happens *before* HPR is initialized, so the listener could accept gateway uplinks before routing/multi-buy/ETS state was ready.

- Moved the server config from `{grpcbox, {servers}}` to `{hpr, {packet_router_server}}` and start it as the **last child** of `hpr_sup`, so the listener only comes up once everything else is in place.
- `grpcbox` still runs (its channel supervisor and gproc tables back the client channels); it just no longer owns the server. In `ct.config` the mock services stay under grpcbox — only the `:8080` server moves.
- Adds `hpr_sup_SUITE` asserting the packet router server is supervised by `hpr_sup` and is the process bound to `:8080`.

### 3. Make `clean` target targeted (`8f9f259`)
Replace `git clean -dXf…` (wipes all git-ignored files) with targeted removal of the generated grpc autogen sources and `_build/`.

## Testing
- `hpr_multi_buy` eunit: all pass (incl. new cold-channel/fail-fast cases).
- `hpr_packet_router_service_SUITE`: pass (gateway connects to `:8080`, routes end-to-end).
- `hpr_sup_SUITE`: pass (server supervised by `hpr_sup`).
- `hpr_routing_SUITE`: the only failure is the pre-existing flaky `multi_buy_requests_test` (passes 3/3 in isolation; exercises the default multi-buy path, unrelated to these changes).

## Reviewer notes
- Draft: local-only `rebar.config`/`rebar.lock` changes (promoting `enacl` to a top-level dep to compile on Erlang 24 + modern clang) are intentionally **not** included.
- The "server starts last" ordering is enforced structurally by child-spec order; `hpr_sup_SUITE` pins the ownership invariant.